### PR TITLE
use LONGTEXT for content

### DIFF
--- a/reposerver/src/main/resources/db/migration/V4__use_longtext.sql
+++ b/reposerver/src/main/resources/db/migration/V4__use_longtext.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `signed_roles` MODIFY COLUMN `content` LONGTEXT NOT NULL;


### PR DESCRIPTION
For the reposerver, the targets.json can get bigger than 2^16 bytes
long so TEXT is not enough, instead we use LONGTEXT which should be
big enough for everyone.
  - Daniel Gates-son

So I tried to run this against the database in ci and it kept the data and have upgraded to `longtext`, I did not try to add more targets since I did not want to add stuff to S3, so I don't know if this will actually fix the issue with not being able to write to the column, but it seems promising.