### PR TITLE
/user_repo returns 404 if namespace don't exists

### DIFF
--- a/reposerver/src/main/scala/com/advancedtelematic/tuf/reposerver/http/RepoResource.scala
+++ b/reposerver/src/main/scala/com/advancedtelematic/tuf/reposerver/http/RepoResource.scala
@@ -72,7 +72,7 @@ class RepoResource(keyserverClient: KeyserverClient, namespaceValidation: Namesp
   private def UserRepoId(namespace: Namespace): Directive1[RepoId] = Directive.Empty.tflatMap { _ =>
     onComplete(repoNamespaceRepo.findFor(namespace)).flatMap {
       case Success(repoId) => provide(repoId)
-      case Failure(_: MissingEntity[_]) => reject(AuthorizationFailedRejection)
+      case Failure(_: MissingEntity[_]) => failWith(MissingEntity[Namespace]())
       case Failure(ex) => failWith(ex)
     }
   }


### PR DESCRIPTION
> jerry 11:59 AM
great, can you also change the 403 in the tuf-repo
this will log out the ui, which waits for 404