### PR TITLE
Publish dependencies sources with s3release

### DIFF
--- a/project/Release.scala
+++ b/project/Release.scala
@@ -23,7 +23,8 @@ object Release {
 
     val cliS3Release: Seq[ReleaseStep] = Seq(
       releaseStepCommand("cli/universal:packageZipTarball"),
-      releaseStepCommand("cli/s3release")
+      releaseStepCommand("cli/s3release"),
+      releaseStepCommand("cli/s3depsRelease")
     )
 
     val allSteps = prepareSteps ++ dockerPublishSteps ++ cliS3Release ++ publishSteps

--- a/project/S3ReleasePlugin.scala
+++ b/project/S3ReleasePlugin.scala
@@ -1,23 +1,33 @@
 package s3Release
 
+import java.io.{BufferedInputStream, BufferedOutputStream}
 import java.nio.file._
+
 import com.amazonaws.auth.{AWSCredentials, AWSCredentialsProvider}
 import com.amazonaws.regions.Regions
 import com.amazonaws.services.s3.AmazonS3ClientBuilder
+import net.virtualvoid.sbt.graph.DependencyGraphPlugin.autoImport._
+import net.virtualvoid.sbt.graph.{Module, ModuleGraph, ModuleId}
+import org.apache.commons.compress.archivers.tar.{TarArchiveEntry, TarArchiveOutputStream}
+import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream
+import org.apache.commons.compress.utils.IOUtils
 import sbt.Keys._
-import sbt.{AutoPlugin, InputKey, Logger, SettingKey}
+import sbt.{AutoPlugin, InputKey, Logger, SettingKey, TaskKey}
 
 import scala.collection.JavaConversions._
+import scala.collection.immutable.HashSet
 
 object S3ReleasePlugin extends AutoPlugin {
   override lazy val projectSettings = s3ReleaseSettings
 
   object autoImport {
     lazy val s3UploadTask = InputKey[Unit]("s3release", "release artifacts to s3")
+    lazy val s3DepsRelease = TaskKey[Unit]("s3depsRelease", "release dependencies sources to s3")
     lazy val s3Region = SettingKey[String]("s3Region")
     lazy val s3AccessKey = SettingKey[String]("s3AccessKey")
     lazy val s3SecretKey = SettingKey[String]("s3SecretKey")
     lazy val s3Bucket = SettingKey[String]("s3Bucket")
+    lazy val s3Credentials = SettingKey[S3Credentials]("s3credentials")
   }
 
   import autoImport._
@@ -32,51 +42,100 @@ object S3ReleasePlugin extends AutoPlugin {
     s3SecretKey := readEnv("AWS_SECRET_ACCESS_KEY"),
     s3Bucket := readEnv("AWS_BUCKET_ID"),
     s3Region := readEnv("AWS_REGION", Option(Regions.EU_CENTRAL_1.getName)),
+    s3Credentials := S3Credentials(s3AccessKey.value, s3SecretKey.value, s3Bucket.value, Regions.fromName(s3Region.value)),
+    s3DepsRelease := {
+      import sbt._
+      val log = streams.value.log
+      val graph = (moduleGraph in Compile in thisProject).value
+      val upload = new S3Upload(log, s3Credentials.value)
+
+      val depsUpload = new S3Dependenciesupload(log, upload)
+      val versionName = s"${moduleName.value}-${version.value}"
+      depsUpload.uploadAll(graph, versionName)
+    },
     s3UploadTask := {
       val force = (token(Space) ~> token("force", "force release overwriting")).?.parsed.isDefined
       val log = streams.value.log
-      val credentials = S3Credentials(s3AccessKey.value, s3SecretKey.value, s3Bucket.value, Regions.fromName(s3Region.value))
-      val releaseUpload = new S3ReleaseUpload(log, credentials)
+      val upload = new S3Upload(log, s3Credentials.value)
+      val releaseUpload = new S3ReleaseUpload(log, upload)
 
       releaseUpload.uploadLatest(force)
     }
   )
 }
 
+class S3Dependenciesupload(log: Logger, upload: S3Upload) {
+  def uploadAll(graph: ModuleGraph, version: String): Unit = {
+    val out = Files.createTempDirectory("s3deps-compressed").resolve(version + "-dep-srcs.tgz")
 
-class S3ReleaseUpload(log: Logger, credentials: S3Credentials) {
-  import java.nio.file.FileSystems
+    val dependenciesPaths = findDependencies(graph)
+    createDependenciesTarball(dependenciesPaths, out)
 
-  lazy val s3Client =
+    upload.uploadObject(Paths.get("deps-srcs"), out, force = false)
+
+    log.info(s"Wrote dependencies tarball to $out")
+  }
+
+  private def isBlacklisted(moduleId: ModuleId): Boolean = {
+    HashSet("libtuf", "cli").exists(moduleId.idString.contains)
+  }
+
+  private def findDependencies(graph:ModuleGraph): List[Path] = {
+    graph.modules.values.flatMap { dependency ⇒
+      val sourcesPath = dependency.jarFile.map { f ⇒
+        Paths.get(f.getAbsolutePath
+          .replace("/bundles/", "/srcs/")
+          .replace("/jars/", "/srcs/")
+          .replaceFirst(".jar$", "-sources.jar"))
+      }
+
+      sourcesPath match {
+        case _ if isBlacklisted(dependency.id) ⇒
+          log.info(s"Not adding ${dependency.id.name}, dependency is blacklisted for source publishing")
+          None
+        case Some(path) if Files.exists(path) ⇒
+          log.info(s"Adding sources for ${dependency.id.name} ")
+          Some(path)
+        case Some(path) ⇒
+          log.warn(s"No sources available for ${dependency.id.name} at path $path")
+          None
+        case None ⇒
+          log.warn(s"No sources available for ${dependency.id.name}")
+          None
+      }
+    }.toList
+  }
+
+  private def createDependenciesTarball(dependencies: List[Path], outFile: Path): Unit = {
+    val out = new TarArchiveOutputStream(new GzipCompressorOutputStream(new BufferedOutputStream(Files.newOutputStream(outFile))))
+
+    dependencies.foreach { path ⇒
+      val entry = new TarArchiveEntry(path.getFileName.toString)
+      entry.setSize(path.toFile.length())
+      out.putArchiveEntry(entry)
+      val is = new BufferedInputStream(Files.newInputStream(path))
+
+      try
+        IOUtils.copy(is, out)
+      finally
+        is.close()
+
+      out.closeArchiveEntry()
+    }
+
+    out.close()
+  }
+}
+
+class S3Upload(log: Logger, credentials: S3Credentials) {
+  private lazy val s3Client =
     AmazonS3ClientBuilder.standard()
       .withCredentials(credentials)
       .withRegion(credentials.region)
       .build()
 
-  def uploadLatest(force: Boolean = false) = {
-    val releasePath = findLatestRelease(log)
-    log.info(s"Using release $releasePath")
-    uploadObject(releasePath, force)
-  }
-
-  private def findLatestRelease(log: Logger): Path = {
-    val matcher = FileSystems.getDefault.getPathMatcher("glob:**/*.tgz")
-
-    val allReleases =
-      Files.list(Paths.get("cli/target/universal/"))
-        .iterator()
-        .filter(matcher.matches)
-        .toVector
-        .sortBy(_.getFileName.toString)(Ordering[String].reverse)
-
-    log.info(s"Available releases: $allReleases")
-
-    allReleases.headOption.getOrElse(throw new Exception("Could not find release to push to s3"))
-  }
-
-  private def uploadObject(path: Path, force: Boolean) = {
-    val fileName = path.getFileName.toString
-
+  def uploadObject(bucketDir: Path, path: Path, force: Boolean): Unit = {
+    val fileName = bucketDir.resolve(path.getFileName.toString).toString
     val exists = s3Client.doesObjectExist(credentials.bucketId, fileName)
 
     if(exists && !force) {
@@ -93,9 +152,35 @@ class S3ReleaseUpload(log: Logger, credentials: S3Credentials) {
     val url = s3Client.getUrl(credentials.bucketId, fileName)
     log.info(s"Url for $fileName release is $url")
   }
+
 }
 
-private case class S3Credentials(accessKey: String, secretKey: String, bucketId: String, region: Regions)
+class S3ReleaseUpload(log: Logger, s3upload: S3Upload) {
+  import java.nio.file.FileSystems
+
+  def uploadLatest(force: Boolean = false): Unit = {
+    val releasePath = findLatestRelease(log)
+    log.info(s"Using release $releasePath")
+    s3upload.uploadObject(Paths.get(""),  releasePath, force)
+  }
+
+  private def findLatestRelease(log: Logger): Path = {
+    val matcher = FileSystems.getDefault.getPathMatcher("glob:**/*.tgz")
+
+    val allReleases =
+      Files.list(Paths.get("cli/target/universal/"))
+        .iterator()
+        .filter(matcher.matches)
+        .toVector
+        .sortBy(_.getFileName.toString)(Ordering[String].reverse)
+
+    log.info(s"Available releases: $allReleases")
+
+    allReleases.headOption.getOrElse(throw new Exception("Could not find release to push to s3"))
+  }
+}
+
+case class S3Credentials(accessKey: String, secretKey: String, bucketId: String, region: Regions)
   extends AWSCredentials with AWSCredentialsProvider {
 
   override def getAWSAccessKeyId: String = accessKey

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,2 +1,5 @@
 
 libraryDependencies += "com.amazonaws" % "aws-java-sdk-s3" % "1.11.214"
+
+libraryDependencies += "org.apache.commons" % "commons-compress" % "1.13"
+

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,3 +7,5 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.1.4")
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.8.5")
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.3")
+
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.0")


### PR DESCRIPTION
Uploading deps sources to s3 at https://ats-tuf-cli-releases.s3-eu-central-1.amazonaws.com/index.html?prefix=deps-srcs/

Deps are obtained using the dependency-graph sbt plugin. 