### PR TITLE
Avoid using RoleType when `TufRole[T <: VersionedRole]` is available

### DIFF
--- a/cli/src/main/scala/com/advancedtelematic/tuf/cli/Cli.scala
+++ b/cli/src/main/scala/com/advancedtelematic/tuf/cli/Cli.scala
@@ -8,7 +8,7 @@ import java.time.temporal.ChronoUnit
 
 import io.circe.syntax._
 import com.advancedtelematic.libtuf.data.TufCodecs._
-import com.advancedtelematic.libtuf.data.TufDataType.{EdKeyType, HardwareIdentifier, KeyId, KeyType, RoleType, TargetFormat, TargetName, TargetVersion}
+import com.advancedtelematic.libtuf.data.TufDataType.{EdKeyType, HardwareIdentifier, KeyId, KeyType, TargetFormat, TargetName, TargetVersion}
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.slf4j.LoggerFactory
 import com.advancedtelematic.libtuf.data.ClientCodecs._
@@ -24,6 +24,7 @@ import com.advancedtelematic.tuf.cli.repo.{RepoManagement, TufRepo}
 
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, ExecutionContext, Future}
+import com.advancedtelematic.libtuf.data.ClientDataType.TufRole._
 
 sealed trait Command
 case object Help extends Command
@@ -353,7 +354,7 @@ object Cli extends App with VersionInfo {
           .toFuture
 
       case PullTargets =>
-        repoServer.zip(tufRepo.readSignedRole[RootRole](RoleType.ROOT).toFuture)
+        repoServer.zip(tufRepo.readSignedRole[RootRole].toFuture)
           .flatMap { case (r, rootRole) => tufRepo.pullTargets(r, rootRole.signed) }
           .map(_ => log.info("Pulled targets"))
 

--- a/cli/src/test/scala/com/advancedtelematic/tuf/cli/repo/RepoManagementSpec.scala
+++ b/cli/src/test/scala/com/advancedtelematic/tuf/cli/repo/RepoManagementSpec.scala
@@ -12,6 +12,7 @@ import com.advancedtelematic.libtuf.data.ClientDataType.RootRole
 import com.advancedtelematic.tuf.cli.CliCodecs.authConfigDecoder
 import com.advancedtelematic.libtuf.data.TufCodecs._
 import com.advancedtelematic.libtuf.data.ClientCodecs._
+import io.circe.syntax._
 
 import scala.util.{Success, Try}
 
@@ -63,7 +64,7 @@ class RepoManagementSpec extends CliSpec {
 
     val repo = repoT.get
 
-    repo.readSignedRole[RootRole](RoleType.ROOT).get.signed shouldBe a[RootRole]
+    repo.readSignedRole[RootRole].get.signed shouldBe a[RootRole]
   }
 
   test("creates base credentials.zip if one does not exist") {
@@ -93,8 +94,7 @@ class RepoManagementSpec extends CliSpec {
     RepoManagement.export(repo, KeyName("targets"), tempPath) shouldBe a[Success[_]]
     val repoFromExported = RepoManagement.initialize(randomName, randomRepoPath, tempPath).get
 
-    import io.circe.syntax._
-    repoFromExported.readSignedRole[RootRole](RoleType.ROOT).get.asJson shouldBe rootRole.asJson
+    repoFromExported.readSignedRole[RootRole].get.asJson shouldBe rootRole.asJson
   }
 
   test("can export zip file") {

--- a/libtuf-server/src/main/scala/com/advancedtelematic/libtuf_server/keyserver/KeyserverClient.scala
+++ b/libtuf-server/src/main/scala/com/advancedtelematic/libtuf_server/keyserver/KeyserverClient.scala
@@ -8,7 +8,7 @@ import akka.stream.ActorMaterializer
 import cats.syntax.show.toShowOps
 import com.advancedtelematic.libats.data.ErrorCode
 import com.advancedtelematic.libats.http.Errors.RawError
-import com.advancedtelematic.libtuf.data.ClientDataType.RootRole
+import com.advancedtelematic.libtuf.data.ClientDataType.{RootRole, TufRole}
 import com.advancedtelematic.libtuf.data.TufDataType.RoleType.RoleType
 import com.advancedtelematic.libtuf.data.TufDataType.{KeyId, KeyType, RepoId, RsaKeyType, SignedPayload, TufKey, TufPrivateKey}
 import com.advancedtelematic.libtuf.data.TufDataType.RoleType._

--- a/reposerver/src/main/scala/com/advancedtelematic/tuf/reposerver/http/OfflineSignedRoleStorage.scala
+++ b/reposerver/src/main/scala/com/advancedtelematic/tuf/reposerver/http/OfflineSignedRoleStorage.scala
@@ -3,9 +3,9 @@ package com.advancedtelematic.tuf.reposerver.http
 import akka.http.scaladsl.model.Uri
 import akka.http.scaladsl.util.FastFuture
 import cats.data.Validated.{Invalid, Valid}
-import cats.data.{NonEmptyList, ValidatedNel}
-import com.advancedtelematic.libtuf.data.ClientDataType.{RootRole, TargetCustom, TargetsRole, VersionedRole}
-import com.advancedtelematic.libtuf.data.TufDataType.{KeyId, RepoId, RoleType, SignedPayload, TargetFilename}
+import cats.data.ValidatedNel
+import com.advancedtelematic.libtuf.data.ClientDataType.{TufRole, TargetCustom, TargetsRole}
+import com.advancedtelematic.libtuf.data.TufDataType.{RepoId, RoleType, SignedPayload, TargetFilename}
 import com.advancedtelematic.tuf.reposerver.data.RepositoryDataType.{SignedRole, StorageMethod, TargetItem}
 import com.advancedtelematic.tuf.reposerver.db.{SignedRoleRepositorySupport, TargetItemRepositorySupport}
 import io.circe.Encoder
@@ -15,6 +15,7 @@ import com.advancedtelematic.libtuf.data.ClientCodecs._
 import slick.jdbc.MySQLProfile.api._
 import com.advancedtelematic.libats.http.HttpCodecs._
 import com.advancedtelematic.libtuf.crypt.TufCrypto
+import com.advancedtelematic.libtuf.data.ClientDataType.TufRole._
 
 import scala.async.Async.{async, await}
 import scala.concurrent.{ExecutionContext, Future}
@@ -60,7 +61,7 @@ class OfflineSignedRoleStorage(keyserverClient: KeyserverClient)
     items.map(_.toValidatedNel).toList.sequenceU
   }
 
-  private def payloadSignatureIsValid[T <: VersionedRole : Encoder](repoId: RepoId, signedPayload: SignedPayload[T]): Future[ValidatedNel[String, SignedPayload[T]]] = async {
+  private def payloadSignatureIsValid[T : TufRole : Encoder](repoId: RepoId, signedPayload: SignedPayload[T]): Future[ValidatedNel[String, SignedPayload[T]]] = async {
     val rootRole = await(keyserverClient.fetchRootRole(repoId)).signed
 
     TufCrypto.payloadSignatureIsValid(rootRole, signedPayload)

--- a/reposerver/src/test/scala/com/advancedtelematic/tuf/reposerver/http/RepoResourceSpec.scala
+++ b/reposerver/src/test/scala/com/advancedtelematic/tuf/reposerver/http/RepoResourceSpec.scala
@@ -13,7 +13,7 @@ import cats.syntax.show.toShowOps
 import cats.syntax.option._
 import com.advancedtelematic.libtuf.crypt.CanonicalJson._
 import com.advancedtelematic.libtuf.crypt.TufCrypto
-import com.advancedtelematic.libtuf.data.ClientDataType.{ClientHashes, ClientTargetItem, RoleTypeToMetaPathOp, RootRole, SnapshotRole, TargetCustom, TargetsRole, TimestampRole}
+import com.advancedtelematic.libtuf.data.ClientDataType.{ClientHashes, ClientTargetItem, RootRole, SnapshotRole, TargetCustom, TargetsRole, TimestampRole}
 import com.advancedtelematic.libtuf_server.data.Messages.{PackageStorageUsage, TufTargetAdded}
 import com.advancedtelematic.libtuf.data.TufDataType.{RepoId, RoleType, _}
 import io.circe.syntax._
@@ -41,6 +41,7 @@ import scala.concurrent.Future
 import com.advancedtelematic.tuf.reposerver.util.NamespaceSpecOps._
 import com.advancedtelematic.tuf.reposerver.util.{ResourceSpec, TufReposerverSpec}
 import eu.timepit.refined.api.Refined
+import com.advancedtelematic.libtuf.data.ClientDataType.RoleTypeOps
 
 import scala.concurrent.ExecutionContext.Implicits
 


### PR DESCRIPTION
This is based on #115 so it is easier to read only the last commit (8f4389b425425cbf4c4b5e756cc9348472be5fc0)

`RoleType.*` and `T <: VersionedRole` hold the same information, ie
the role type, so this is a first attempt to unify this into a single
typeclass. The idea is to completely remove RoleType at some point,
but that would take much more work, since reposerver relies heavily on
this enum in particular for slick code.

Unfortunately this PR doesn't go all the way to the RoleType removal
but I think it is a good first step.