### PR TITLE
test whether server returns proper error message on wrong key type

### DIFF
--- a/keyserver/src/main/scala/com/advancedtelematic/tuf/keyserver/http/RootRoleResource.scala
+++ b/keyserver/src/main/scala/com/advancedtelematic/tuf/keyserver/http/RootRoleResource.scala
@@ -85,7 +85,7 @@ class RootRoleResource(vaultClient: VaultClient)
           complete(f)
         }
     } ~
-    path("keys" / "targets") {
+    (put & path("keys" / "targets")) {
       entity(as[TufKey]) { tufKey =>
         val f = rootRoleKeyEdit.addPublicKey(repoId, RoleType.TARGETS, tufKey)
         complete(f)


### PR DESCRIPTION
The fix was already implemented in some other PR, just added test from bug ticket and changed error message.

Also force akka endpoint to use `put` as the request is reject was method instead since `entity` would not match.