### PR TITLE
dockerUpdateLatest only works when not scoped

### DIFF
--- a/keyserver/src/test/scala/com/advancedtelematic/tuf/util/ResourceSpec.scala
+++ b/keyserver/src/test/scala/com/advancedtelematic/tuf/util/ResourceSpec.scala
@@ -20,7 +20,7 @@ import scala.concurrent.{Future, Promise}
 
 trait LongHttpRequest {
   implicit def default(implicit system: ActorSystem) =
-    RouteTestTimeout(10.seconds.dilated(system))
+    RouteTestTimeout(15.seconds.dilated(system))
 }
 
 trait HttpClientSpecSupport {

--- a/project/Packaging.scala
+++ b/project/Packaging.scala
@@ -14,7 +14,7 @@ object Packaging {
 
       packageName in Docker := distPackageName,
 
-      dockerUpdateLatest in Docker := true,
+      dockerUpdateLatest := true,
 
       defaultLinuxInstallLocation in Docker := s"/opt/${moduleName.value}",
 


### PR DESCRIPTION
Led to errors like http://teamcity.staging.internal.atsgarage.com:8111/viewLog.html?buildId=12259&buildTypeId=Staging_Publish_OtaTufPublish&tab=buildLog&_focus=1002

Also increase timeout for route tests since they fail regularly

E.g.,
http://teamcity.staging.internal.atsgarage.com:8111/viewLog.html?buildId=12222&tab=buildResultsDiv&buildTypeId=Staging_Test_OtaTufTest