### PR TITLE
Refactor libtuf for deterministic signatures

### DIFF
--- a/cli/src/main/scala/com/advancedtelematic/tuf/cli/CliUtil.scala
+++ b/cli/src/main/scala/com/advancedtelematic/tuf/cli/CliUtil.scala
@@ -6,7 +6,7 @@ import java.nio.file.Path
 import cats.data.Validated.{Invalid, Valid}
 import com.advancedtelematic.libtuf.crypt.TufCrypto
 import com.advancedtelematic.libtuf.data.ClientDataType.RootRole
-import com.advancedtelematic.libtuf.data.TufDataType.SignedPayload
+import com.advancedtelematic.libtuf.data.TufDataType.{JsonSignedPayload, SignedPayload}
 import org.slf4j.LoggerFactory
 
 import scala.concurrent.Future

--- a/cli/src/main/scala/com/advancedtelematic/tuf/cli/repo/RepoManagement.scala
+++ b/cli/src/main/scala/com/advancedtelematic/tuf/cli/repo/RepoManagement.scala
@@ -11,14 +11,16 @@ import com.advancedtelematic.libtuf.data.ClientDataType.{RootRole, TufRole}
 import com.advancedtelematic.libtuf.data.ClientCodecs._
 import com.advancedtelematic.libtuf.data.ClientDataType.TufRole._
 import com.advancedtelematic.libtuf.data.TufCodecs._
-import com.advancedtelematic.libtuf.data.TufDataType.{SignedPayload, TufKey, TufPrivateKey}
+import com.advancedtelematic.libtuf.data.TufDataType.{JsonSignedPayload, SignedPayload, TufKey, TufPrivateKey}
 import com.advancedtelematic.tuf.cli.DataType.{AuthConfig, KeyName, RepoName, TreehubConfig}
 import com.advancedtelematic.tuf.cli.repo.TufRepo.{MissingCredentialsZipFile, RepoAlreadyInitialized, TreehubConfigError}
+import com.advancedtelematic.libtuf.data.TufCodecs._
 import com.advancedtelematic.tuf.cli.CliCodecs._
 import com.advancedtelematic.tuf.cli.CliUtil
 import io.circe.syntax._
 import io.circe.{Decoder, Encoder}
 import org.slf4j.LoggerFactory
+
 import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext
 import scala.io.Source

--- a/cli/src/test/scala/com/advancedtelematic/tuf/cli/TufRepoSpec.scala
+++ b/cli/src/test/scala/com/advancedtelematic/tuf/cli/TufRepoSpec.scala
@@ -10,7 +10,7 @@ import cats.syntax.either._
 import com.advancedtelematic.libtuf.crypt.SignedPayloadSignatureOps._
 import com.advancedtelematic.libtuf.data.ClientDataType.{RoleKeys, RootRole, TargetCustom, TargetsRole, TufRole}
 import com.advancedtelematic.libtuf.data.ClientCodecs._
-import com.advancedtelematic.libtuf.data.TufDataType.{Ed25519KeyType, KeyType, RoleType, SignedPayload, TargetFormat, TargetName, TargetVersion, TufKey, ValidTargetFilename}
+import com.advancedtelematic.libtuf.data.TufDataType.{Ed25519KeyType, KeyType, RoleType, JsonSignedPayload, SignedPayload, TargetFormat, TargetName, TargetVersion, TufKey, ValidTargetFilename}
 import com.advancedtelematic.libtuf.data.TufCodecs._
 import com.advancedtelematic.tuf.cli.DataType.{KeyName, RepoName}
 import com.advancedtelematic.tuf.cli.repo.{CliKeyStorage, TufRepo}
@@ -22,9 +22,8 @@ import com.advancedtelematic.tuf.cli.repo.TufRepo.{RoleMissing, RootPullError}
 import scala.concurrent.Future
 import io.circe.syntax._
 
-import scala.util.{Failure, Success}
+import scala.util.Success
 import cats.syntax.option._
-import org.scalatest.path
 
 class TufRepoSpec extends CliSpec with KeyTypeSpecSupport {
 
@@ -404,7 +403,7 @@ class TufRepoSpec extends CliSpec with KeyTypeSpecSupport {
     val oldRoot = repo.pullRoot(reposerverClient, skipLocalValidation = true).futureValue
 
     val newUnsignedRoot = oldRoot.signed.copy(version = oldRoot.signed.version + 1)
-    reposerverClient.setRoot(SignedPayload(Seq.empty, newUnsignedRoot))
+    reposerverClient.setRoot(SignedPayload(Seq.empty, newUnsignedRoot, newUnsignedRoot.asJson))
 
     val error = repo.pullRoot(reposerverClient, skipLocalValidation = false).failed.futureValue
 
@@ -422,7 +421,7 @@ class TufRepoSpec extends CliSpec with KeyTypeSpecSupport {
     val oldRoot = repo.pullRoot(reposerverClient, skipLocalValidation = true).futureValue
 
     val newUnsignedRoot = oldRoot.signed.copy(version = oldRoot.signed.version + 10)
-    reposerverClient.setRoot(SignedPayload(Seq.empty, newUnsignedRoot))
+    reposerverClient.setRoot(SignedPayload(Seq.empty, newUnsignedRoot, newUnsignedRoot.asJson))
 
     val error = repo.pullRoot(reposerverClient, skipLocalValidation = false).failed.futureValue
 

--- a/keyserver/src/main/scala/com/advancedtelematic/tuf/keyserver/data/KeyServerDataType.scala
+++ b/keyserver/src/main/scala/com/advancedtelematic/tuf/keyserver/data/KeyServerDataType.scala
@@ -1,14 +1,19 @@
 package com.advancedtelematic.tuf.keyserver.data
 
 import java.security.PublicKey
+import java.time.Instant
 import java.util.UUID
 
 import com.advancedtelematic.libats.data.UUIDKey.{UUIDKey, UUIDKeyObj}
 import com.advancedtelematic.libats.slick.db.SlickEncryptedColumn.EncryptedColumn
+import com.advancedtelematic.libtuf.data.ClientDataType.RootRole
 import com.advancedtelematic.libtuf.data.TufDataType.RoleType.RoleType
-import com.advancedtelematic.libtuf.data.TufDataType.{KeyId, KeyType, RepoId, TufKey, TufKeyPair, TufPrivateKey}
+import com.advancedtelematic.libtuf.data.TufDataType.{KeyId, KeyType, RepoId, JsonSignedPayload, SignedPayload, TufKey, TufKeyPair, TufPrivateKey}
 import com.advancedtelematic.tuf.keyserver.data.KeyServerDataType.KeyGenRequestStatus.KeyGenRequestStatus
+import com.advancedtelematic.tuf.keyserver.http.Errors
+import io.circe.{Decoder, Json}
 
+import scala.concurrent.Future
 import scala.util.Try
 
 object KeyServerDataType {
@@ -30,11 +35,22 @@ object KeyServerDataType {
     require(keyType.crypto.validKeySize(keySize), s"Invalid keysize ($keySize) for $keyType")
   }
 
+  object SignedRootRole {
+    import io.circe.syntax._
+    import com.advancedtelematic.libtuf.data.ClientCodecs._
+
+    def fromSignedPayload(repoId: RepoId, payload: SignedPayload[RootRole]): SignedRootRole = {
+      val content = SignedPayload(payload.signatures, payload.signed, payload.json)
+      SignedRootRole(repoId, content, payload.signed.expires, payload.signed.version)
+    }
+  }
+
+  case class SignedRootRole(repoId: RepoId, content: SignedPayload[RootRole], expiresAt: Instant, version: Int)
+
   case class Key(id: KeyId, repoId: RepoId, roleType: RoleType, keyType: KeyType, publicKey: PublicKey,
                  privateKey: TufPrivateKey) {
     def toTufKey: TufKey = keyType.crypto.convertPublic(publicKey)
 
-    // TODO: Cant I get rid of this?
     def toTufKeyPair: Try[TufKeyPair] = keyType.crypto.castToKeyPair(toTufKey, privateKey)
   }
 }

--- a/keyserver/src/main/scala/com/advancedtelematic/tuf/keyserver/http/Errors.scala
+++ b/keyserver/src/main/scala/com/advancedtelematic/tuf/keyserver/http/Errors.scala
@@ -6,6 +6,7 @@ import com.advancedtelematic.libtuf.data.TufDataType.RepoId
 import com.advancedtelematic.tuf.keyserver.data.KeyServerDataType.KeyGenId
 import io.circe.syntax._
 import com.advancedtelematic.libtuf.data.ErrorCodes
+import com.advancedtelematic.libats.http.Errors.Error
 
 object Errors {
   val KeysNotReady = RawError(ErrorCodes.KeyServer.KeysNotReady, StatusCodes.Locked, "A key generation request exists")

--- a/keyserver/src/main/scala/com/advancedtelematic/tuf/keyserver/http/RootRoleResource.scala
+++ b/keyserver/src/main/scala/com/advancedtelematic/tuf/keyserver/http/RootRoleResource.scala
@@ -80,7 +80,7 @@ class RootRoleResource()
           val f = signedRootRoles.findForSign(repoId)
           complete(f)
         } ~
-        (post & entity(as[SignedPayload[RootRole]])) { signedPayload =>
+        (post & entity(as[JsonSignedPayload])) { signedPayload =>
           val f: Future[ToResponseMarshallable] =
             signedRootRoles.persistUserSigned(repoId, signedPayload).map {
               case Valid(_) =>

--- a/keyserver/src/main/scala/com/advancedtelematic/tuf/keyserver/roles/RoleSigning.scala
+++ b/keyserver/src/main/scala/com/advancedtelematic/tuf/keyserver/roles/RoleSigning.scala
@@ -2,12 +2,14 @@ package com.advancedtelematic.tuf.keyserver.roles
 
 import akka.http.scaladsl.util.FastFuture
 import com.advancedtelematic.libtuf.crypt.TufCrypto
+import com.advancedtelematic.libtuf.data.ClientDataType.VersionedRole
 import com.advancedtelematic.libtuf.data.TufDataType.RoleType.RoleType
 import com.advancedtelematic.libtuf.data.TufDataType.{RepoId, _}
 import com.advancedtelematic.tuf.keyserver.db._
 import com.advancedtelematic.tuf.keyserver.http.Errors
-import io.circe.Encoder
+import io.circe.{Encoder, Json}
 import slick.jdbc.MySQLProfile.api._
+import io.circe.syntax._
 
 import scala.async.Async._
 import scala.concurrent.{ExecutionContext, Future}
@@ -17,28 +19,28 @@ class RoleSigning()(implicit val db: Database, val ec: ExecutionContext)
 
   import com.advancedtelematic.libtuf.data.RootManipulationOps._
 
-  def signWithRole[T : Encoder](repoId: RepoId, roleType: RoleType, payload: T): Future[SignedPayload[T]] = async {
-    val root = await(signedRootRoleRepo.findLatest(repoId)).signed
+  def signWithRole(repoId: RepoId, roleType: RoleType, payload: Json): Future[JsonSignedPayload] = async {
+    val root = await(signedRootRoleRepo.findLatest(repoId)).content.signed
     val keys = root.roleKeys(roleType)
 
     if(keys.isEmpty)
       throw Errors.RoleKeysNotFound
-    else
-      await(signWithKeys(payload, keys))
+    else {
+      val signatures = await(signWithKeys(payload, keys))
+      JsonSignedPayload(signatures, payload)
+    }
 
   }.recoverWith {
     case KeyRepository.KeyNotFound => Future.failed(Errors.PrivateKeysNotFound)
   }
 
-  protected [roles] def signWithKeys[T : Encoder](payload: T, keys: Seq[TufKey]): Future[SignedPayload[T]] = {
+  protected [roles] def signWithKeys(payload: Json, keys: Seq[TufKey]): Future[Seq[ClientSignature]] = {
     Future.sequence {
       keys.map(signForClient(payload))
-    }.map { signatures =>
-      SignedPayload(signatures, payload)
     }
   }
 
-  protected [roles] def signForClient[T : Encoder](payload: T)(key: TufKey): Future[ClientSignature] = {
+  protected [roles] def signForClient(payload: Json)(key: TufKey): Future[ClientSignature] = {
     fetchPrivateKey(key).map { privateKey =>
       val signature = TufCrypto.signPayload(privateKey, payload)
       ClientSignature(key.id, signature.method, signature.sig)

--- a/keyserver/src/test/scala/com/advancedtelematic/tuf/keyserver/http/SignedRootRolesSpec.scala
+++ b/keyserver/src/test/scala/com/advancedtelematic/tuf/keyserver/http/SignedRootRolesSpec.scala
@@ -45,7 +45,8 @@ class SignedRootRolesSpec extends TufKeyserverSpec with DatabaseSpec
     async {
       await(keyGenRepo.persist(rootKeyGenRequest))
       await(keyGenerationOp(rootKeyGenRequest))
-      val signed = await(signedRootRoles.findAndPersist(repoId))
+      await(signedRootRoles.findAndPersist(repoId))
+      val signed = await(signedRootRoles.findLatest(repoId))
 
       val rootKeyId = signed.signed.roles(RoleType.ROOT).keyids.head
       val publicKey = signed.signed.keys(rootKeyId).keyval
@@ -58,11 +59,10 @@ class SignedRootRolesSpec extends TufKeyserverSpec with DatabaseSpec
     }.futureValue
   }
 
-  keyTypeTest("persists signed payload when finding ") { keyType =>
+  keyTypeTest("persists signed payload when finding") { keyType =>
     val repoId = RepoId.generate()
     val rootKeyGenRequest = KeyGenRequest(KeyGenId.generate(),
       repoId, KeyGenRequestStatus.REQUESTED, RoleType.ROOT, keyType.crypto.defaultKeySize, keyType)
-
 
     async {
       await(keyGenRepo.persist(rootKeyGenRequest))
@@ -70,7 +70,8 @@ class SignedRootRolesSpec extends TufKeyserverSpec with DatabaseSpec
 
       val signed = await(signedRootRoles.findAndPersist(repoId))
 
-      await(signedRootRoleRepo.findLatest(repoId)).asJson shouldBe signed.asJson
+      await(signedRootRoleRepo.findLatest(repoId)).content.signed.asJson shouldBe signed.signed.asJson
+      await(signedRootRoleRepo.findLatest(repoId)).content.asJson shouldBe signed.asJson
     }.futureValue
   }
 }

--- a/keyserver/src/test/scala/com/advancedtelematic/tuf/keyserver/roles/RoleSigningSpec.scala
+++ b/keyserver/src/test/scala/com/advancedtelematic/tuf/keyserver/roles/RoleSigningSpec.scala
@@ -1,6 +1,5 @@
 package com.advancedtelematic.tuf.keyserver.roles
 
-import com.advancedtelematic.libats.slick.db.SlickEncryptedColumn.EncryptedColumn
 import com.advancedtelematic.libtuf.crypt.CanonicalJson._
 import com.advancedtelematic.libtuf.data.TufDataType.{KeyType, RepoId, RoleType, Signature, TufKeyPair}
 import com.advancedtelematic.tuf.keyserver.data.KeyServerDataType._
@@ -51,19 +50,19 @@ class RoleSigningSpec extends TufKeyserverSpec with DatabaseSpec with PatienceCo
   }
 
   roleSignTest("signs a payload with a key ") { (_, dbKey) =>
-    val signature = roleSigning.signForClient(payload)(dbKey.toTufKey).futureValue
+    val signature = roleSigning.signForClient(payload.asJson)(dbKey.toTufKey).futureValue
     new String(Base64.decode(signature.sig.value)) shouldBe a[String]
   }
 
   roleSignTest("generates valid signatures") { (keyPair, dbKey) =>
-    val clientSignature = roleSigning.signForClient(payload)(dbKey.toTufKey).futureValue
+    val clientSignature = roleSigning.signForClient(payload.asJson)(dbKey.toTufKey).futureValue
     val signature = Signature(clientSignature.sig, clientSignature.method)
 
     TufCrypto.isValid(signature, keyPair.pubkey.keyval, payload.asJson.canonical.getBytes) shouldBe true
   }
 
   roleSignTest("generates valid signatures when verifying with canonical representation") { (keyPair, dbKey) =>
-    val clientSignature = roleSigning.signForClient(payload)(dbKey.toTufKey).futureValue
+    val clientSignature = roleSigning.signForClient(payload.asJson)(dbKey.toTufKey).futureValue
     val signature = Signature(clientSignature.sig, clientSignature.method)
 
     val canonicalJson = """{"arrayMapProp":[{"aaa":0,"bbb":1}],"mapProp":{"aa":0,"bb":1},"propertyA":"some A","propertyB":"some B"}""".getBytes

--- a/libtuf-server/src/main/scala/com/advancedtelematic/libtuf_server/data/TufSlickMappings.scala
+++ b/libtuf-server/src/main/scala/com/advancedtelematic/libtuf_server/data/TufSlickMappings.scala
@@ -6,7 +6,7 @@ import com.advancedtelematic.libats.data.DataType.Checksum
 import com.advancedtelematic.libtuf.crypt.TufCrypto
 import com.advancedtelematic.libtuf.crypt.TufCrypto.KeyOps
 import com.advancedtelematic.libtuf.data.ClientDataType.TargetCustom
-import com.advancedtelematic.libtuf.data.TufDataType.{EcPrime256KeyType, Ed25519KeyType, KeyType, RoleType, RsaKeyType, SignedPayload, TufKey, TufPrivateKey}
+import com.advancedtelematic.libtuf.data.TufDataType.{EcPrime256KeyType, Ed25519KeyType, KeyType, RoleType, RsaKeyType, JsonSignedPayload, TufKey, TufPrivateKey}
 import com.advancedtelematic.libtuf.data.ClientCodecs._
 import com.advancedtelematic.libtuf.data.TufCodecs._
 import com.advancedtelematic.libats.slick.db.{SlickCirceMapper, SlickEncryptedColumn}
@@ -42,7 +42,7 @@ object TufSlickMappings {
 
   implicit val targetCustomMapper = SlickCirceMapper.circeMapper[TargetCustom]
 
-  implicit val jsonSignedPayloadMapper = SlickCirceMapper.circeMapper[SignedPayload[Json]]
+  implicit val jsonSignedPayloadMapper = SlickCirceMapper.circeMapper[JsonSignedPayload]
 
   implicit val tufKeyMapper = SlickCirceMapper.circeMapper[TufKey]
 

--- a/libtuf/src/main/scala/com/advancedtelematic/libtuf/crypt/SignedPayloadSignatureOps.scala
+++ b/libtuf/src/main/scala/com/advancedtelematic/libtuf/crypt/SignedPayloadSignatureOps.scala
@@ -1,6 +1,6 @@
 package com.advancedtelematic.libtuf.crypt
 
-import com.advancedtelematic.libtuf.data.TufDataType.{SignedPayload, TufKey}
+import com.advancedtelematic.libtuf.data.TufDataType.{JsonSignedPayload, SignedPayload, TufKey}
 import io.circe.Encoder
 
 
@@ -9,7 +9,7 @@ object SignedPayloadSignatureOps  {
   implicit class SignedPayloadSignatureOps[T : Encoder](value: SignedPayload[T]) {
     def isValidFor(tufKey: TufKey): Boolean =
       value.signatures.exists { sig =>
-        TufCrypto.isValid(sig, tufKey.keyval, value.signed)
+        TufCrypto.isValid(sig, tufKey.keyval, value.json)
       }
   }
 }

--- a/libtuf/src/main/scala/com/advancedtelematic/libtuf/crypt/TufCrypto.scala
+++ b/libtuf/src/main/scala/com/advancedtelematic/libtuf/crypt/TufCrypto.scala
@@ -4,11 +4,11 @@ import java.io.{StringReader, StringWriter}
 import java.security
 import java.security.interfaces.RSAPublicKey
 import java.security.spec.{PKCS8EncodedKeySpec, X509EncodedKeySpec}
-import java.security.{Signature => _, _}
+import java.security.{Signature ⇒ _, _}
 
 import org.bouncycastle.jce.ECNamedCurveTable
 import org.bouncycastle.jce.spec.ECParameterSpec
-import com.advancedtelematic.libtuf.data.TufDataType.{ClientSignature, EcPrime256KeyType, EcPrime256TufKey, EcPrime256TufKeyPair, EcPrime256TufPrivateKey, Ed25519KeyType, Ed25519TufKey, Ed25519TufKeyPair, Ed25519TufPrivateKey, KeyId, KeyType, RSATufKey, RSATufKeyPair, RSATufPrivateKey, RsaKeyType, Signature, SignatureMethod, SignedPayload, TufKey, TufKeyPair, TufPrivateKey, ValidKeyId, ValidSignature}
+import com.advancedtelematic.libtuf.data.TufDataType.{ClientSignature, EcPrime256KeyType, EcPrime256TufKey, EcPrime256TufKeyPair, EcPrime256TufPrivateKey, Ed25519KeyType, Ed25519TufKey, Ed25519TufKeyPair, Ed25519TufPrivateKey, KeyId, KeyType, RSATufKey, RSATufKeyPair, RSATufPrivateKey, RsaKeyType, Signature, SignatureMethod, JsonSignedPayload, SignedPayload, TufKey, TufKeyPair, TufPrivateKey, ValidKeyId, ValidSignature}
 import org.bouncycastle.crypto.digests.SHA256Digest
 import org.bouncycastle.openssl.jcajce.{JcaPEMKeyConverter, JcaPEMWriter}
 import org.bouncycastle.util.encoders.{Base64, Hex}
@@ -87,8 +87,8 @@ object TufCrypto {
 
   lazy val ecPrime256Crypto = new ECPrime256Crypto()
 
-  def signPayload[T : Encoder](key: TufPrivateKey, payload: T): Signature = {
-    val bytes = payload.asJson.canonical.getBytes
+  def signPayload(key: TufPrivateKey, payload: Json): Signature = {
+    val bytes = payload.canonical.getBytes
     sign(key.keytype, key.keyval, bytes)
   }
 
@@ -118,9 +118,9 @@ object TufCrypto {
     signer.verify(decodedSig)
   }
 
-  def isValid[T : Encoder](signature: ClientSignature, publicKey: PublicKey, value: T): Boolean = {
+  def isValid(signature: ClientSignature, publicKey: PublicKey, value: Json): Boolean = {
     val sig = Signature(signature.sig, signature.method)
-    TufCrypto.isValid(sig, publicKey, value.asJson.canonical.getBytes)
+    TufCrypto.isValid(sig, publicKey, value.canonical.getBytes)
   }
 
   implicit class PublicKeyOps(key: PublicKey) {

--- a/libtuf/src/main/scala/com/advancedtelematic/libtuf/data/ClientDataType.scala
+++ b/libtuf/src/main/scala/com/advancedtelematic/libtuf/data/ClientDataType.scala
@@ -26,8 +26,7 @@ object ClientDataType {
 
   case class ClientTargetItem(hashes: ClientHashes,
                               length: Long, custom: Option[Json]) {
-    def customParsed[T](implicit decoder: Decoder[T]): Option[T] =
-      custom.flatMap(c => decoder.decodeJson(c).toOption)
+    def customParsed[T : Decoder]: Option[T] = custom.flatMap(_.as[T].toOption)
   }
 
   case class RoleKeys(keyids: Seq[KeyId], threshold: Int)

--- a/libtuf/src/main/scala/com/advancedtelematic/libtuf/data/ErrorCodes.scala
+++ b/libtuf/src/main/scala/com/advancedtelematic/libtuf/data/ErrorCodes.scala
@@ -10,5 +10,6 @@ object ErrorCodes {
     val PrivateKeysNotFound = ErrorCode("private_keys_not_found")
     val KeyGenerationFailed = ErrorCode("key_generation_failed")
     val InvalidRootRole = ErrorCode("invalid_root_role")
+    val SignedRootRoleDecodingFailed = ErrorCode("signed_root_role_decoding_failed")
   }
 }

--- a/libtuf/src/main/scala/com/advancedtelematic/libtuf/reposerver/UserReposerverClient.scala
+++ b/libtuf/src/main/scala/com/advancedtelematic/libtuf/reposerver/UserReposerverClient.scala
@@ -6,7 +6,7 @@ import com.advancedtelematic.libats.data.DataType.ValidChecksum
 import com.advancedtelematic.libtuf.data.ClientCodecs._
 import com.advancedtelematic.libtuf.data.ClientDataType.{RootRole, TargetsRole}
 import com.advancedtelematic.libtuf.data.TufCodecs._
-import com.advancedtelematic.libtuf.data.TufDataType.{KeyId, SignedPayload, TufKeyPair}
+import com.advancedtelematic.libtuf.data.TufDataType.{KeyId, JsonSignedPayload, SignedPayload, TufKeyPair}
 import com.advancedtelematic.libtuf.http.SHttpjServiceClient
 import com.advancedtelematic.libtuf.http.SHttpjServiceClient.HttpResponse
 import com.advancedtelematic.libtuf.reposerver.UserReposerverClient.{RoleChecksumNotValid, RoleNotFound, TargetsResponse}

--- a/reposerver/src/main/scala/com/advancedtelematic/tuf/reposerver/data/RepositoryDataType.scala
+++ b/reposerver/src/main/scala/com/advancedtelematic/tuf/reposerver/data/RepositoryDataType.scala
@@ -6,12 +6,13 @@ import java.time.Instant
 import akka.http.scaladsl.model.Uri
 import com.advancedtelematic.libats.data.DataType.Checksum
 import com.advancedtelematic.libtuf.data.ClientDataType.{MetaItem, MetaPath, _}
-import com.advancedtelematic.libtuf.data.TufDataType.{RepoId, SignedPayload, TargetFilename}
+import com.advancedtelematic.libtuf.data.TufDataType.{RepoId, JsonSignedPayload, TargetFilename}
 import com.advancedtelematic.libtuf.data.TufDataType.RoleType.RoleType
 import io.circe.{Encoder, Json}
 import io.circe.syntax._
 import com.advancedtelematic.libtuf.data.TufCodecs._
 import com.advancedtelematic.libtuf.crypt.CanonicalJson._
+import com.advancedtelematic.libtuf.data.TufCodecs
 import com.advancedtelematic.libtuf_server.crypto.Sha256Digest
 
 object RepositoryDataType {
@@ -24,7 +25,7 @@ object RepositoryDataType {
 
   case class TargetItem(repoId: RepoId, filename: TargetFilename, uri: Option[Uri], checksum: Checksum, length: Long, custom: Option[TargetCustom] = None, storageMethod: StorageMethod = Managed)
 
-  case class SignedRole(repoId: RepoId, roleType: RoleType, content: SignedPayload[Json], checksum: Checksum, length: Long, version: Int, expireAt: Instant)
+  case class SignedRole(repoId: RepoId, roleType: RoleType, content: JsonSignedPayload, checksum: Checksum, length: Long, version: Int, expireAt: Instant)
 
   implicit class SignedRoleMetaItemOps(signedRole: SignedRole) {
     def asMetaRole: (MetaPath, MetaItem) = {
@@ -42,10 +43,10 @@ object RepositoryDataType {
   }
 
   object SignedRole {
-    def withChecksum[T : Encoder](repoId: RepoId, roleType: RoleType, content: SignedPayload[T], version: Int, expireAt: Instant): SignedRole = {
+    def withChecksum(repoId: RepoId, roleType: RoleType, content: JsonSignedPayload, version: Int, expireAt: Instant): SignedRole = {
       val canonicalJson = content.asJson.canonical
       val checksum = Sha256Digest.digest(canonicalJson.getBytes)
-      SignedRole(repoId, roleType, SignedPayload(content.signatures, content.signed.asJson), checksum, canonicalJson.length, version, expireAt: Instant)
+      SignedRole(repoId, roleType, content, checksum, canonicalJson.length, version, expireAt: Instant)
     }
   }
 }

--- a/reposerver/src/main/scala/com/advancedtelematic/tuf/reposerver/db/Repository.scala
+++ b/reposerver/src/main/scala/com/advancedtelematic/tuf/reposerver/db/Repository.scala
@@ -152,15 +152,6 @@ protected[db] class SignedRoleRepository()(implicit val db: Database, val ec: Ex
         .update(signedRole)
     }
 
-  def findAll(roleTypes: RoleType*): Source[SignedRole, NotUsed] =
-    Source.fromPublisher {
-      db.stream {
-        signedRoles
-          .filter(_.roleType.inSet(roleTypes))
-          .result
-      }
-    }
-
   def find(repoId: RepoId, roleType: RoleType): Future[SignedRole] =
     db.run {
       signedRoles

--- a/reposerver/src/main/scala/com/advancedtelematic/tuf/reposerver/db/Schema.scala
+++ b/reposerver/src/main/scala/com/advancedtelematic/tuf/reposerver/db/Schema.scala
@@ -6,7 +6,7 @@ import akka.http.scaladsl.model.Uri
 import com.advancedtelematic.libats.data.DataType.{Checksum, Namespace}
 import com.advancedtelematic.libtuf.data.ClientDataType.TargetCustom
 import com.advancedtelematic.libtuf.data.TufDataType.RoleType.RoleType
-import com.advancedtelematic.libtuf.data.TufDataType.{RepoId, SignedPayload, TargetFilename, TargetName, TargetVersion}
+import com.advancedtelematic.libtuf.data.TufDataType.{RepoId, JsonSignedPayload, TargetFilename, TargetName, TargetVersion}
 import com.advancedtelematic.tuf.reposerver.data.RepositoryDataType.{SignedRole, TargetItem}
 import io.circe.Json
 import slick.jdbc.MySQLProfile.api._
@@ -42,7 +42,7 @@ object Schema {
   class SignedRoleTable(tag: Tag) extends Table[SignedRole](tag, "signed_roles") {
     def repoId = column[RepoId]("repo_id")
     def roleType = column[RoleType]("role_type")
-    def content = column[SignedPayload[Json]]("content")
+    def content = column[JsonSignedPayload]("content")
     def checksum = column[Checksum]("checksum")
     def length = column[Long]("length")
     def version = column[Int]("version")

--- a/reposerver/src/test/scala/com/advancedtelematic/tuf/reposerver/db/SignedRoleRepositorySpec.scala
+++ b/reposerver/src/test/scala/com/advancedtelematic/tuf/reposerver/db/SignedRoleRepositorySpec.scala
@@ -4,7 +4,7 @@ import java.time.Instant
 
 import akka.http.scaladsl.model.StatusCodes
 import com.advancedtelematic.libats.data.DataType.{Checksum, HashMethod, ValidChecksum}
-import com.advancedtelematic.libtuf.data.TufDataType.{RepoId, RoleType, SignedPayload}
+import com.advancedtelematic.libtuf.data.TufDataType.{RepoId, RoleType, JsonSignedPayload}
 import io.circe.Json
 import com.advancedtelematic.libats.http.Errors.RawError
 import com.advancedtelematic.libats.test.DatabaseSpec
@@ -27,7 +27,7 @@ class SignedRoleRepositorySpec extends TufReposerverSpec with DatabaseSpec with 
     val repo = new SignedRoleRepository()
 
     val checksum = Checksum(HashMethod.SHA256, refineV[ValidChecksum]("41b3b0f27a091fe87c3e0f23b4194a8f5f54b1a3c275d0633cb1da1596cc4a6f").right.get)
-    val role = SignedRole(RepoId.generate(), RoleType.TARGETS, SignedPayload(Seq.empty, Json.Null), checksum, 0, 1, Instant.now)
+    val role = SignedRole(RepoId.generate(), RoleType.TARGETS, JsonSignedPayload(Seq.empty, Json.Null), checksum, 0, 1, Instant.now)
 
     val ex = async {
       await(repo.persist(role))

--- a/reposerver/src/test/scala/com/advancedtelematic/tuf/reposerver/http/OfflineSignedRoleStorageSpec.scala
+++ b/reposerver/src/test/scala/com/advancedtelematic/tuf/reposerver/http/OfflineSignedRoleStorageSpec.scala
@@ -10,7 +10,7 @@ import cats.data.Validated.Valid
 import cats.data.ValidatedNel
 import com.advancedtelematic.libats.test.DatabaseSpec
 import com.advancedtelematic.libtuf.data.ClientDataType.{ClientTargetItem, TargetCustom, TargetsRole}
-import com.advancedtelematic.libtuf.data.TufDataType.{RepoId, RoleType, TargetFilename, TargetFormat, ValidTargetFilename}
+import com.advancedtelematic.libtuf.data.TufDataType.{RepoId, RoleType, JsonSignedPayload, SignedPayload, TargetFilename, TargetFormat, ValidTargetFilename}
 import com.advancedtelematic.tuf.reposerver.util._
 import com.advancedtelematic.libtuf.data.ClientCodecs._
 import com.advancedtelematic.libats.codecs.CirceCodecs._
@@ -61,8 +61,8 @@ class OfflineSignedRoleStorageSpec extends TufReposerverSpec with DatabaseSpec w
 
   def storeOffline(repoId: RepoId, targets: Map[TargetFilename, ClientTargetItem], version: Int): Future[ValidatedNel[String, (Seq[TargetItem], SignedRole)]] = {
     val targetsRole = TargetsRole(Instant.now.plusSeconds(3600), targets, version)
-    val payload = keyserver.sign(repoId, RoleType.TARGETS, targetsRole).futureValue
-    subject.store(repoId, payload)
+    val payload = keyserver.sign(repoId, RoleType.TARGETS, targetsRole.asJson).futureValue
+    subject.store(repoId, SignedPayload(payload.signatures, targetsRole, targetsRole.asJson))
   }
 
   keyTypeTest("allows previously online targets to contain empty custom metadata") { keyType =>


### PR DESCRIPTION
Use raw json when verifying and signing payloads

Save raw json in database when saving root.json in keyserver