### PR TITLE
Refresh role dependencies when role is refreshed

### DIFF
--- a/cli/src/main/scala/com/advancedtelematic/tuf/cli/repo/RepoManagement.scala
+++ b/cli/src/main/scala/com/advancedtelematic/tuf/cli/repo/RepoManagement.scala
@@ -87,7 +87,7 @@ object RepoManagement {
 
     def copyRole[T : TufRole : Encoder : Decoder](repo: TufRepo, dest: ZipOutputStream): Try[Unit] = {
       repo.readSignedRole[T].map { role =>
-        dest.putNextEntry(new ZipEntry(role.signed.toMetaPath.value))
+        dest.putNextEntry(new ZipEntry(role.signed.metaPath.value))
         dest.write(role.asJson.spaces2.getBytes)
         dest.closeEntry()
       }
@@ -194,7 +194,7 @@ protected object ZipRepoInitialization {
     } yield ()
 
     def writeRoot(src: ZipFile): Try[Unit] = for {
-      rootIs <- Try(src.getInputStream(src.getEntry(TufRole.rootTufRole.toMetaPath.value)))
+      rootIs <- Try(src.getInputStream(src.getEntry(TufRole.rootTufRole.metaPath.value)))
       rootRole <- CliUtil.readJsonFrom[SignedPayload[RootRole]](rootIs)
       _ <- tufRepo.writeSignedRole(rootRole)
     } yield ()

--- a/cli/src/main/scala/com/advancedtelematic/tuf/cli/repo/TufRepo.scala
+++ b/cli/src/main/scala/com/advancedtelematic/tuf/cli/repo/TufRepo.scala
@@ -68,7 +68,7 @@ object TufRepo {
 
   case class TargetsPullError(msg: String) extends Exception(s"Could not pull targets from server $msg") with NoStackTrace
 
-  case class RoleMissing[T](rolePath: String)(implicit ev: TufRole[T]) extends Throwable(s"Missing role ${ev.toMetaPath.toString()} at $rolePath") with NoStackTrace
+  case class RoleMissing[T](rolePath: String)(implicit ev: TufRole[T]) extends Throwable(s"Missing role ${ev.metaPath.toString()} at $rolePath") with NoStackTrace
 
   case class RootPullError(errors: NonEmptyList[String]) extends Throwable("Could not validate a valid root.json chain:\n" + errors.toList.mkString("\n")) with NoStackTrace
 
@@ -242,14 +242,14 @@ abstract class TufRepo(val name: RepoName, val repoPath: Path)(implicit ec: Exec
   }
 
   def readUnsignedRole[T : Decoder](implicit ev: TufRole[T]): Try[T] = {
-    val path = rolesPath.resolve("unsigned").resolve(ev.toMetaPath.value)
+    val path = rolesPath.resolve("unsigned").resolve(ev.metaPath.value)
     withExistingRolePath[T, T](path) { p =>
       parseFile(p.toFile).flatMap(_.as[T]).toTry
     }
   }
 
   def readSignedRole[T : Encoder : Decoder](implicit ev: TufRole[T]): Try[SignedPayload[T]] = {
-    val path = rolesPath.resolve(ev.toMetaPath.value)
+    val path = rolesPath.resolve(ev.metaPath.value)
     withExistingRolePath[T, SignedPayload[T]](path) { p =>
       parseFile(p.toFile).flatMap(_.as[SignedPayload[T]]).toTry
     }
@@ -268,10 +268,10 @@ abstract class TufRepo(val name: RepoName, val repoPath: Path)(implicit ec: Exec
   }
 
   def writeUnsignedRole[T : TufRole : Encoder](role: T): Try[Path] =
-    writeRole(rolesPath.resolve("unsigned"), role.toMetaPath, role)
+    writeRole(rolesPath.resolve("unsigned"), role.metaPath, role)
 
   def writeSignedRole[T : TufRole : Encoder](signedPayload: SignedPayload[T]): Try[Path] =
-    writeRole(rolesPath, signedPayload.signed.toMetaPath, signedPayload)
+    writeRole(rolesPath, signedPayload.signed.metaPath, signedPayload)
 
   private def writeRole[T : Encoder](path: Path, metaPath: MetaPath, payload: T): Try[Path] = Try {
     val rolePath = path.resolve(metaPath.value)

--- a/libtuf/src/main/scala/com/advancedtelematic/libtuf/data/ClientCodecs.scala
+++ b/libtuf/src/main/scala/com/advancedtelematic/libtuf/data/ClientCodecs.scala
@@ -57,6 +57,7 @@ object ClientCodecs {
     def validateRoleType: Decoder[T] = {
       decoder.validate({ c =>
         val _type = c.downField("_type").as[String].valueOr(throw _).toLowerCase.capitalize
+
         _type == tr.typeStr
       },
         s"Invalid type for role: ${tr.roleType}"

--- a/reposerver/src/main/scala/com/advancedtelematic/tuf/reposerver/data/RepositoryDataType.scala
+++ b/reposerver/src/main/scala/com/advancedtelematic/tuf/reposerver/data/RepositoryDataType.scala
@@ -6,14 +6,12 @@ import java.time.Instant
 import akka.http.scaladsl.model.Uri
 import com.advancedtelematic.libats.data.DataType.Checksum
 import com.advancedtelematic.libtuf.data.ClientDataType.{MetaItem, MetaPath, _}
-import com.advancedtelematic.libtuf.data.TufDataType.{RepoId, JsonSignedPayload, TargetFilename}
-import com.advancedtelematic.libtuf.data.TufDataType.RoleType.RoleType
-import io.circe.{Encoder, Json}
+import com.advancedtelematic.libtuf.data.TufDataType.{JsonSignedPayload, RepoId, TargetFilename}
 import io.circe.syntax._
 import com.advancedtelematic.libtuf.data.TufCodecs._
 import com.advancedtelematic.libtuf.crypt.CanonicalJson._
-import com.advancedtelematic.libtuf.data.TufCodecs
 import com.advancedtelematic.libtuf_server.crypto.Sha256Digest
+import io.circe.Decoder
 
 object RepositoryDataType {
   object StorageMethod extends Enumeration {
@@ -25,12 +23,26 @@ object RepositoryDataType {
 
   case class TargetItem(repoId: RepoId, filename: TargetFilename, uri: Option[Uri], checksum: Checksum, length: Long, custom: Option[TargetCustom] = None, storageMethod: StorageMethod = Managed)
 
-  case class SignedRole(repoId: RepoId, roleType: RoleType, content: JsonSignedPayload, checksum: Checksum, length: Long, version: Int, expireAt: Instant)
+  case class SignedRole[T : TufRole](repoId: RepoId, content: JsonSignedPayload, checksum: Checksum, length: Long, version: Int, expiresAt: Instant) {
+    def role(implicit dec: Decoder[T]): T = content.signed.as[T] match {
+      case Left(err) =>
+        throw new IllegalArgumentException(s"Could not decode a role saved in database as ${tufRole.roleType} but not parseable as such a type: $err")
+      case Right(p) => p
+    }
 
-  implicit class SignedRoleMetaItemOps(signedRole: SignedRole) {
     def asMetaRole: (MetaPath, MetaItem) = {
-      val hashes = Map(signedRole.checksum.method -> signedRole.checksum.hash)
-      signedRole.roleType.toMetaPath -> MetaItem(hashes, signedRole.length, signedRole.version)
+      val hashes = Map(checksum.method -> checksum.hash)
+      tufRole.metaPath -> MetaItem(hashes, length, version)
+    }
+
+    def tufRole: TufRole[T] = implicitly[TufRole[T]]
+  }
+
+  object SignedRole {
+    def withChecksum[T : TufRole](repoId: RepoId, content: JsonSignedPayload, version: Int, expireAt: Instant): SignedRole[T] = {
+      val canonicalJson = content.asJson.canonical
+      val checksum = Sha256Digest.digest(canonicalJson.getBytes)
+      SignedRole[T](repoId, content, checksum, canonicalJson.length, version, expireAt)
     }
   }
 
@@ -40,13 +52,5 @@ object RepositoryDataType {
 
   implicit class AkkaUriToJavaUriConversion(value: Uri) {
     def toURI: URI = URI.create(value.toString)
-  }
-
-  object SignedRole {
-    def withChecksum(repoId: RepoId, roleType: RoleType, content: JsonSignedPayload, version: Int, expireAt: Instant): SignedRole = {
-      val canonicalJson = content.asJson.canonical
-      val checksum = Sha256Digest.digest(canonicalJson.getBytes)
-      SignedRole(repoId, roleType, content, checksum, canonicalJson.length, version, expireAt: Instant)
-    }
   }
 }

--- a/reposerver/src/main/scala/com/advancedtelematic/tuf/reposerver/db/DBDataType.scala
+++ b/reposerver/src/main/scala/com/advancedtelematic/tuf/reposerver/db/DBDataType.scala
@@ -1,0 +1,23 @@
+package com.advancedtelematic.tuf.reposerver.db
+
+import java.time.Instant
+
+import com.advancedtelematic.libats.data.DataType.Checksum
+import com.advancedtelematic.libtuf.data.ClientDataType.TufRole
+import com.advancedtelematic.libtuf.data.TufDataType.RoleType.RoleType
+import com.advancedtelematic.libtuf.data.TufDataType.{JsonSignedPayload, RepoId}
+import com.advancedtelematic.tuf.reposerver.data.RepositoryDataType.SignedRole
+
+protected [db] object DBDataType {
+  protected [db] case class DbSignedRole(repoId: RepoId, roleType: RoleType, content: JsonSignedPayload, checksum: Checksum, length: Long, version: Int, expireAt: Instant)
+
+  protected [db] implicit class DbSignedRoleOps(value: DbSignedRole) {
+    def asSignedRole[T : TufRole]: SignedRole[T] =
+      SignedRole[T](value.repoId, value.content, value.checksum, value.length, value.version, value.expireAt)
+  }
+
+  protected [db] implicit class SignedRoleAsDbSignedRoleOps[_](value: SignedRole[_]) {
+    def asDbSignedRole: DbSignedRole =
+      DbSignedRole(value.repoId, value.tufRole.roleType, value.content, value.checksum, value.length, value.version, value.expiresAt)
+  }
+}

--- a/reposerver/src/main/scala/com/advancedtelematic/tuf/reposerver/db/Schema.scala
+++ b/reposerver/src/main/scala/com/advancedtelematic/tuf/reposerver/db/Schema.scala
@@ -6,13 +6,13 @@ import akka.http.scaladsl.model.Uri
 import com.advancedtelematic.libats.data.DataType.{Checksum, Namespace}
 import com.advancedtelematic.libtuf.data.ClientDataType.TargetCustom
 import com.advancedtelematic.libtuf.data.TufDataType.RoleType.RoleType
-import com.advancedtelematic.libtuf.data.TufDataType.{RepoId, JsonSignedPayload, TargetFilename, TargetName, TargetVersion}
-import com.advancedtelematic.tuf.reposerver.data.RepositoryDataType.{SignedRole, TargetItem}
-import io.circe.Json
+import com.advancedtelematic.libtuf.data.TufDataType.{JsonSignedPayload, RepoId, TargetFilename}
+import com.advancedtelematic.tuf.reposerver.data.RepositoryDataType.TargetItem
 import slick.jdbc.MySQLProfile.api._
 import com.advancedtelematic.tuf.reposerver.data.RepositoryDataType.StorageMethod._
 import SlickMappings._
 import com.advancedtelematic.libtuf_server.data.Requests.TargetComment
+import com.advancedtelematic.tuf.reposerver.db.DBDataType.DbSignedRole
 
 object Schema {
   import com.advancedtelematic.libats.slick.codecs.SlickRefined._
@@ -39,7 +39,7 @@ object Schema {
 
   protected [db] val targetItems = TableQuery[TargetItemTable]
 
-  class SignedRoleTable(tag: Tag) extends Table[SignedRole](tag, "signed_roles") {
+  class SignedRoleTable(tag: Tag) extends Table[DbSignedRole](tag, "signed_roles") {
     def repoId = column[RepoId]("repo_id")
     def roleType = column[RoleType]("role_type")
     def content = column[JsonSignedPayload]("content")
@@ -50,7 +50,7 @@ object Schema {
 
     def pk = primaryKey("signed_role_pk", (repoId, roleType))
 
-    override def * = (repoId, roleType, content, checksum, length, version, expiresAt) <> ((SignedRole.apply _).tupled, SignedRole.unapply)
+    override def * = (repoId, roleType, content, checksum, length, version, expiresAt) <> ((DbSignedRole.apply _).tupled, DbSignedRole.unapply)
   }
 
   protected [db] val signedRoles = TableQuery[SignedRoleTable]

--- a/reposerver/src/main/scala/com/advancedtelematic/tuf/reposerver/db/TreehubStorageMethodFix.scala
+++ b/reposerver/src/main/scala/com/advancedtelematic/tuf/reposerver/db/TreehubStorageMethodFix.scala
@@ -21,7 +21,7 @@ class TreehubStorageMethodFix(implicit
                               val mat: Materializer,
                               val system: ActorSystem,
                               val ec: ExecutionContext
-                             ) extends SignedRoleRepositorySupport {
+                             ) {
 
   import Schema.targetItems
 

--- a/reposerver/src/main/scala/com/advancedtelematic/tuf/reposerver/http/RepoResource.scala
+++ b/reposerver/src/main/scala/com/advancedtelematic/tuf/reposerver/http/RepoResource.scala
@@ -214,7 +214,7 @@ class RepoResource(keyserverClient: KeyserverClient, namespaceValidation: Namesp
     results.toList.foldMap(toValidatedNel)
   }
 
-  def newTargetsAdded(repoId: RepoId, namespace: Namespace, signedPayload: SignedPayload[TargetsRole], checksum: Option[RoleChecksum]): Future[ValidatedNel[Throwable, SignedRole]] = {
+  def newTargetsAdded(repoId: RepoId, namespace: Namespace, signedPayload: SignedPayload[TargetsRole], checksum: Option[RoleChecksum]): Future[ValidatedNel[Throwable, SignedRole[TargetsRole]]] = {
     // get the items before they get removed from the DB
     val previousTargetItemsF: Future[Seq[TargetItem]] = targetItemRepo.findFor(repoId)
 

--- a/reposerver/src/main/scala/com/advancedtelematic/tuf/reposerver/http/RoleRefresh.scala
+++ b/reposerver/src/main/scala/com/advancedtelematic/tuf/reposerver/http/RoleRefresh.scala
@@ -1,0 +1,103 @@
+package com.advancedtelematic.tuf.reposerver.http
+
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+import com.advancedtelematic.libtuf.data.ClientDataType.{MetaItem, MetaPath, SnapshotRole, TargetsRole, TimestampRole, TufRole, _}
+import com.advancedtelematic.libtuf.data.TufDataType.RepoId
+import com.advancedtelematic.libtuf_server.keyserver.KeyserverClient
+import com.advancedtelematic.tuf.reposerver.data.RepositoryDataType.SignedRole
+import com.advancedtelematic.tuf.reposerver.db.SignedRoleRepositorySupport
+import io.circe.syntax._
+import io.circe.{Decoder, Encoder}
+import slick.jdbc.MySQLProfile.api._
+import com.advancedtelematic.libtuf.data.ClientCodecs._
+
+import scala.async.Async.{async, await}
+import scala.concurrent.{ExecutionContext, Future}
+
+
+class RoleSigner(repoId: RepoId, keyserverClient: KeyserverClient)(implicit ec: ExecutionContext) {
+  def apply[T : Encoder](role: T)(implicit tufRole: TufRole[T]): Future[SignedRole[T]] = {
+    keyserverClient.sign(repoId, tufRole.roleType, role.asJson).map { signedRole =>
+      SignedRole.withChecksum[T](repoId, signedRole, role.version, role.expires)
+    }
+  }
+}
+
+class RepoRoleRefresh(signFn: RoleSigner)(implicit val db: Database, val ec: ExecutionContext) extends SignedRoleRepositorySupport {
+  val roleRefresh = new RoleRefresh(signFn)
+
+  private def findExisting[T](repoId: RepoId)(implicit tufRole: TufRole[T]): Future[SignedRole[T]] = {
+    signedRoleRepository.find[T](repoId)
+  }
+
+  private def commitRefresh[T : TufRole](refreshedRole: SignedRole[T], dependencies: List[SignedRole[_]]): Future[SignedRole[T]] = async {
+    await(signedRoleRepository.persistAll(refreshedRole :: dependencies))
+    refreshedRole
+  }
+
+  def refreshTargets(repoId: RepoId): Future[SignedRole[TargetsRole]] = async {
+    val existingTargets = await(findExisting[TargetsRole](repoId))
+    val existingSnapshots = await(findExisting[SnapshotRole](repoId))
+    val existingTimestamps = await(findExisting[TimestampRole](repoId))
+    val (newTargets, dependencies) = await(roleRefresh.refreshTargets(existingTargets, existingTimestamps, existingSnapshots))
+    await(commitRefresh(newTargets, dependencies))
+  }
+
+  def refreshSnapshots(repoId: RepoId): Future[SignedRole[SnapshotRole]] = async {
+    val existingTargets = await(findExisting[TargetsRole](repoId))
+    val existingSnapshots = await(findExisting[SnapshotRole](repoId))
+    val existingTimestamps = await(findExisting[TimestampRole](repoId))
+    val (newSnapshots, dependencies) = await(roleRefresh.refreshSnapshots(existingSnapshots, existingTimestamps, existingTargets))
+    await(commitRefresh(newSnapshots, dependencies))
+  }
+
+  def refreshTimestamp(repoId: RepoId): Future[SignedRole[TimestampRole]] = async {
+    val existingTimestamp = await(findExisting[TimestampRole](repoId))
+    val existingSnapshots = await(findExisting[SnapshotRole](repoId))
+    val newTimestamp = await(roleRefresh.refreshTimestamps(existingTimestamp, existingSnapshots))
+    await(commitRefresh(newTimestamp, List.empty))
+  }
+}
+
+class RoleRefresh(signFn: RoleSigner)(implicit ec: ExecutionContext) {
+
+  def refreshTargets(existingTargets: SignedRole[TargetsRole],
+                     existingTimestamps: SignedRole[TimestampRole],
+                     existingSnapshots: SignedRole[SnapshotRole]): Future[(SignedRole[TargetsRole], List[SignedRole[_]])] = async {
+    val newTargetsRole = refreshRole[TargetsRole](existingTargets)
+    val signedTargets = await(signFn(newTargetsRole))
+    val (newSnapshots, dependencies) = await(refreshSnapshots(existingSnapshots, existingTimestamps, signedTargets))
+
+    (signedTargets, newSnapshots :: dependencies)
+  }
+
+  def refreshSnapshots(existingSnapshots: SignedRole[SnapshotRole],
+                       existingTimestamps: SignedRole[TimestampRole],
+                       newTargets: SignedRole[TargetsRole]): Future[(SignedRole[SnapshotRole], List[SignedRole[_]])] = async {
+    val refreshed = refreshRole[SnapshotRole](existingSnapshots)
+
+    val newMeta: Map[MetaPath, MetaItem] = existingSnapshots.role.meta + newTargets.asMetaRole
+    val newSnapshot = SnapshotRole(newMeta, refreshed.expires, refreshed.version)
+
+    val signedSnapshot = await(signFn(newSnapshot))
+
+    val timestampRole = await(refreshTimestamps(existingTimestamps, signedSnapshot))
+
+    (signedSnapshot, List(timestampRole))
+  }
+
+  def refreshTimestamps(existingTimestamps: SignedRole[TimestampRole],
+                        newSnapshots: SignedRole[SnapshotRole]): Future[SignedRole[TimestampRole]] = async {
+    val refreshed = refreshRole[TimestampRole](existingTimestamps)
+    val newTimestamp = TimestampRole(Map(newSnapshots.asMetaRole), refreshed.expires, refreshed.version)
+    val signedTimestamps = await(signFn(newTimestamp))
+    signedTimestamps
+  }
+
+  private def refreshRole[T : Decoder](existing: SignedRole[T])(implicit tufRole: TufRole[T]): T = {
+    val nextExpires = Instant.now.plus(1, ChronoUnit.DAYS)
+    tufRole.refreshRole(existing.role, _ + 1, nextExpires)
+  }
+}

--- a/reposerver/src/test/scala/com/advancedtelematic/tuf/reposerver/db/DbSignedRoleRepositorySpec.scala
+++ b/reposerver/src/test/scala/com/advancedtelematic/tuf/reposerver/db/DbSignedRoleRepositorySpec.scala
@@ -4,11 +4,11 @@ import java.time.Instant
 
 import akka.http.scaladsl.model.StatusCodes
 import com.advancedtelematic.libats.data.DataType.{Checksum, HashMethod, ValidChecksum}
-import com.advancedtelematic.libtuf.data.TufDataType.{RepoId, RoleType, JsonSignedPayload}
+import com.advancedtelematic.libtuf.data.TufDataType.{JsonSignedPayload, RepoId, RoleType}
 import io.circe.Json
 import com.advancedtelematic.libats.http.Errors.RawError
 import com.advancedtelematic.libats.test.DatabaseSpec
-import com.advancedtelematic.tuf.reposerver.data.RepositoryDataType.SignedRole
+import com.advancedtelematic.tuf.reposerver.db.DBDataType.DbSignedRole
 import com.advancedtelematic.tuf.reposerver.util.TufReposerverSpec
 import eu.timepit.refined.refineV
 import org.scalatest.concurrent.PatienceConfiguration
@@ -17,17 +17,17 @@ import org.scalatest.time.{Seconds, Span}
 import scala.async.Async._
 import scala.concurrent.ExecutionContext
 
-class SignedRoleRepositorySpec extends TufReposerverSpec with DatabaseSpec with PatienceConfiguration {
+class DbSignedRoleRepositorySpec extends TufReposerverSpec with DatabaseSpec with PatienceConfiguration {
 
   implicit val ec = ExecutionContext.global
 
   override implicit def patienceConfig = PatienceConfig().copy(timeout = Span(10, Seconds))
 
   test("Fails with Conflict if version cannot be bumped") {
-    val repo = new SignedRoleRepository()
+    val repo = new DbSignedRoleRepository()
 
     val checksum = Checksum(HashMethod.SHA256, refineV[ValidChecksum]("41b3b0f27a091fe87c3e0f23b4194a8f5f54b1a3c275d0633cb1da1596cc4a6f").right.get)
-    val role = SignedRole(RepoId.generate(), RoleType.TARGETS, JsonSignedPayload(Seq.empty, Json.Null), checksum, 0, 1, Instant.now)
+    val role = DbSignedRole(RepoId.generate(), RoleType.TARGETS, JsonSignedPayload(Seq.empty, Json.Null), checksum, 0, 1, Instant.now)
 
     val ex = async {
       await(repo.persist(role))

--- a/reposerver/src/test/scala/com/advancedtelematic/tuf/reposerver/db/SignedRoleDbTestUtil.scala
+++ b/reposerver/src/test/scala/com/advancedtelematic/tuf/reposerver/db/SignedRoleDbTestUtil.scala
@@ -1,0 +1,22 @@
+package com.advancedtelematic.tuf.reposerver.db
+
+import com.advancedtelematic.libtuf.data.ClientDataType.TufRole
+import com.advancedtelematic.tuf.reposerver.data.RepositoryDataType.SignedRole
+import slick.jdbc.MySQLProfile.api._
+import com.advancedtelematic.libats.slick.db.SlickUUIDKey._
+import com.advancedtelematic.libtuf_server.data.TufSlickMappings._
+import DBDataType._
+
+import scala.concurrent.Future
+
+object SignedRoleDbTestUtil {
+  implicit class SignedRoleRepositoryTestOps(value: SignedRoleRepository) {
+    def update[T: TufRole](signedRole: SignedRole[T]): Future[Int] =
+      value.db.run {
+        Schema.signedRoles
+          .filter(_.repoId === signedRole.repoId)
+          .filter(_.roleType === signedRole.tufRole.roleType)
+          .update(signedRole.asDbSignedRole)
+      }
+  }
+}

--- a/reposerver/src/test/scala/com/advancedtelematic/tuf/reposerver/http/OfflineSignedRoleStorageSpec.scala
+++ b/reposerver/src/test/scala/com/advancedtelematic/tuf/reposerver/http/OfflineSignedRoleStorageSpec.scala
@@ -10,7 +10,7 @@ import cats.data.Validated.Valid
 import cats.data.ValidatedNel
 import com.advancedtelematic.libats.test.DatabaseSpec
 import com.advancedtelematic.libtuf.data.ClientDataType.{ClientTargetItem, TargetCustom, TargetsRole}
-import com.advancedtelematic.libtuf.data.TufDataType.{RepoId, RoleType, JsonSignedPayload, SignedPayload, TargetFilename, TargetFormat, ValidTargetFilename}
+import com.advancedtelematic.libtuf.data.TufDataType.{RepoId, RoleType, SignedPayload, TargetFilename, TargetFormat, ValidTargetFilename}
 import com.advancedtelematic.tuf.reposerver.util._
 import com.advancedtelematic.libtuf.data.ClientCodecs._
 import com.advancedtelematic.libats.codecs.CirceCodecs._
@@ -59,7 +59,7 @@ class OfflineSignedRoleStorageSpec extends TufReposerverSpec with DatabaseSpec w
 
   val signedRoleGeneration = new SignedRoleGeneration(keyserver)
 
-  def storeOffline(repoId: RepoId, targets: Map[TargetFilename, ClientTargetItem], version: Int): Future[ValidatedNel[String, (Seq[TargetItem], SignedRole)]] = {
+  def storeOffline(repoId: RepoId, targets: Map[TargetFilename, ClientTargetItem], version: Int): Future[ValidatedNel[String, (Seq[TargetItem], SignedRole[TargetsRole])]] = {
     val targetsRole = TargetsRole(Instant.now.plusSeconds(3600), targets, version)
     val payload = keyserver.sign(repoId, RoleType.TARGETS, targetsRole.asJson).futureValue
     subject.store(repoId, SignedPayload(payload.signatures, targetsRole, targetsRole.asJson))

--- a/reposerver/src/test/scala/com/advancedtelematic/tuf/reposerver/http/RepoResourceSpec.scala
+++ b/reposerver/src/test/scala/com/advancedtelematic/tuf/reposerver/http/RepoResourceSpec.scala
@@ -17,7 +17,7 @@ import cats.syntax.option._
 import cats.syntax.show._
 import com.advancedtelematic.libats.codecs.CirceCodecs._
 import com.advancedtelematic.libats.data.DataType.HashMethod
-import com.advancedtelematic.libats.data.{ErrorCode, ErrorRepresentation}
+import com.advancedtelematic.libats.data.ErrorRepresentation
 import com.advancedtelematic.libats.data.RefinedUtils.RefineTry
 import com.advancedtelematic.libats.http.Errors.RawError
 import com.advancedtelematic.libats.http.HttpCodecs._
@@ -36,13 +36,14 @@ import com.advancedtelematic.libtuf_server.keyserver.KeyserverClient
 import com.advancedtelematic.libtuf_server.reposerver.ReposerverClient.RequestTargetItem
 import com.advancedtelematic.tuf.reposerver.data.RepositoryDataType.SignedRole
 import com.advancedtelematic.tuf.reposerver.db.SignedRoleRepositorySupport
+import com.advancedtelematic.tuf.reposerver.db.SignedRoleDbTestUtil._
 import com.advancedtelematic.tuf.reposerver.target_store.TargetStoreEngine.{TargetBytes, TargetRetrieveResult}
 import com.advancedtelematic.tuf.reposerver.util.NamespaceSpecOps._
 import com.advancedtelematic.tuf.reposerver.util._
 import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
 import eu.timepit.refined.api.Refined
 import io.circe.syntax._
-import io.circe.{Decoder, Encoder, Json, ParsingFailure}
+import io.circe.{Decoder, Encoder, Json}
 import org.scalatest.concurrent.{PatienceConfiguration, ScalaFutures}
 import org.scalatest.prop.Whenever
 import org.scalatest.time.{Seconds, Span}
@@ -55,7 +56,7 @@ trait RepoSupport extends ResourceSpec with SignedRoleRepositorySupport with Sca
   implicit val ec = executor
 
   def makeRoleChecksumHeader(repoId: RepoId) =
-    RoleChecksumHeader(signedRoleRepo.find(repoId, RoleType.TARGETS).futureValue.checksum.hash)
+    RoleChecksumHeader(signedRoleRepository.find[TargetsRole](repoId).futureValue.checksum.hash)
 
   val testFile = {
     val checksum = Sha256Digest.digest("hi".getBytes)
@@ -300,8 +301,8 @@ class RepoResourceSpec extends TufReposerverSpec with RepoSupport
       responseAs[SignedPayload[TimestampRole]]
     }
 
-    val newRole = SignedRole.withChecksum(repoId, RoleType.TIMESTAMP, role.asJsonSignedPayload, role.signed.version, Instant.now.minus(1, ChronoUnit.DAYS))
-    signedRoleRepo.update(newRole).futureValue
+    val newRole = SignedRole.withChecksum[TimestampRole](repoId, role.asJsonSignedPayload, role.signed.version, Instant.now.minus(1, ChronoUnit.DAYS))
+    signedRoleRepository.update(newRole).futureValue
 
     Get(apiUri(s"repo/${repoId.show}/timestamp.json")) ~> routes ~> check {
       status shouldBe StatusCodes.OK
@@ -318,8 +319,8 @@ class RepoResourceSpec extends TufReposerverSpec with RepoSupport
       responseAs[SignedPayload[SnapshotRole]]
     }
 
-    val newRole = SignedRole.withChecksum(repoId, RoleType.SNAPSHOT, role.asJsonSignedPayload, role.signed.version, Instant.now.minus(1, ChronoUnit.DAYS))
-    signedRoleRepo.update(newRole).futureValue
+    val newRole = SignedRole.withChecksum[SnapshotRole](repoId, role.asJsonSignedPayload, role.signed.version, Instant.now.minus(1, ChronoUnit.DAYS))
+    signedRoleRepository.update(newRole).futureValue
 
     Get(apiUri(s"repo/${repoId.show}/snapshot.json")) ~> routes ~> check {
       status shouldBe StatusCodes.OK
@@ -336,8 +337,8 @@ class RepoResourceSpec extends TufReposerverSpec with RepoSupport
       responseAs[SignedPayload[TargetsRole]]
     }
 
-    val newRole = SignedRole.withChecksum(repoId, RoleType.TARGETS, role.asJsonSignedPayload, role.signed.version, Instant.now.minus(1, ChronoUnit.DAYS))
-    signedRoleRepo.update(newRole).futureValue
+    val newRole = SignedRole.withChecksum[TargetsRole](repoId, role.asJsonSignedPayload, role.signed.version, Instant.now.minus(1, ChronoUnit.DAYS))
+    signedRoleRepository.update(newRole).futureValue
 
     Get(apiUri(s"repo/${repoId.show}/targets.json")) ~> routes ~> check {
       status shouldBe StatusCodes.OK
@@ -387,10 +388,10 @@ class RepoResourceSpec extends TufReposerverSpec with RepoSupport
       val signed = responseAs[SignedPayload[SnapshotRole]].signed
 
       val targetLength = targetsRole.asJson.canonical.length
-      signed.meta(RoleType.TARGETS.toMetaPath).length shouldBe targetLength
+      signed.meta(RoleType.TARGETS.metaPath).length shouldBe targetLength
 
       val rootLength = rootRole.asJson.canonical.length
-      signed.meta(RoleType.ROOT.toMetaPath).length shouldBe rootLength
+      signed.meta(RoleType.ROOT.metaPath).length shouldBe rootLength
     }
   }
 
@@ -411,7 +412,7 @@ class RepoResourceSpec extends TufReposerverSpec with RepoSupport
         status shouldBe StatusCodes.OK
         val snapshotRole = responseAs[SignedPayload[SnapshotRole]].signed
 
-        val hash = snapshotRole.meta(RoleType.TARGETS.toMetaPath).hashes(targetsCheckSum.method)
+        val hash = snapshotRole.meta(RoleType.TARGETS.metaPath).hashes(targetsCheckSum.method)
 
         hash shouldBe targetsCheckSum.hash
       }

--- a/reposerver/src/test/scala/com/advancedtelematic/tuf/reposerver/http/RepoResourceSpec.scala
+++ b/reposerver/src/test/scala/com/advancedtelematic/tuf/reposerver/http/RepoResourceSpec.scala
@@ -301,13 +301,15 @@ class RepoResourceSpec extends TufReposerverSpec with RepoSupport
       responseAs[SignedPayload[TimestampRole]]
     }
 
-    val newRole = SignedRole.withChecksum[TimestampRole](repoId, role.asJsonSignedPayload, role.signed.version, Instant.now.minus(1, ChronoUnit.DAYS))
+    val expiredInstant = Instant.now.minus(1, ChronoUnit.DAYS)
+    val expiredJsonPayload = JsonSignedPayload(role.signatures, role.asJsonSignedPayload.signed.deepMerge(Json.obj("expires" -> expiredInstant.asJson)))
+
+    val newRole = SignedRole.withChecksum[TimestampRole](repoId, expiredJsonPayload, role.signed.version, expiredInstant)
     signedRoleRepository.update(newRole).futureValue
 
     Get(apiUri(s"repo/${repoId.show}/timestamp.json")) ~> routes ~> check {
       status shouldBe StatusCodes.OK
       val updatedRole = responseAs[SignedPayload[TimestampRole]].signed
-
       updatedRole.version shouldBe role.signed.version + 1
       updatedRole.expires.isAfter(Instant.now) shouldBe true
     }
@@ -319,7 +321,10 @@ class RepoResourceSpec extends TufReposerverSpec with RepoSupport
       responseAs[SignedPayload[SnapshotRole]]
     }
 
-    val newRole = SignedRole.withChecksum[SnapshotRole](repoId, role.asJsonSignedPayload, role.signed.version, Instant.now.minus(1, ChronoUnit.DAYS))
+    val expiredInstant = Instant.now.minus(1, ChronoUnit.DAYS)
+    val expiredJsonPayload = JsonSignedPayload(role.signatures, role.asJsonSignedPayload.signed.deepMerge(Json.obj("expires" -> expiredInstant.asJson)))
+
+    val newRole = SignedRole.withChecksum[SnapshotRole](repoId, expiredJsonPayload, role.signed.version, expiredInstant)
     signedRoleRepository.update(newRole).futureValue
 
     Get(apiUri(s"repo/${repoId.show}/snapshot.json")) ~> routes ~> check {
@@ -337,7 +342,10 @@ class RepoResourceSpec extends TufReposerverSpec with RepoSupport
       responseAs[SignedPayload[TargetsRole]]
     }
 
-    val newRole = SignedRole.withChecksum[TargetsRole](repoId, role.asJsonSignedPayload, role.signed.version, Instant.now.minus(1, ChronoUnit.DAYS))
+    val expiredInstant = Instant.now.minus(1, ChronoUnit.DAYS)
+    val expiredJsonPayload = JsonSignedPayload(role.signatures, role.asJsonSignedPayload.signed.deepMerge(Json.obj("expires" -> expiredInstant.asJson)))
+
+    val newRole = SignedRole.withChecksum[TargetsRole](repoId, expiredJsonPayload, role.signed.version, expiredInstant)
     signedRoleRepository.update(newRole).futureValue
 
     Get(apiUri(s"repo/${repoId.show}/targets.json")) ~> routes ~> check {

--- a/reposerver/src/test/scala/com/advancedtelematic/tuf/reposerver/http/SignedRoleGenerationSpec.scala
+++ b/reposerver/src/test/scala/com/advancedtelematic/tuf/reposerver/http/SignedRoleGenerationSpec.scala
@@ -1,0 +1,76 @@
+package com.advancedtelematic.tuf.reposerver.http
+
+import java.time.Instant
+
+import akka.http.scaladsl.util.FastFuture
+import com.advancedtelematic.libats.test.DatabaseSpec
+import com.advancedtelematic.libtuf.data.ClientCodecs._
+import com.advancedtelematic.libtuf.data.ClientDataType.{TimestampRole, _}
+import com.advancedtelematic.libtuf.data.TufDataType.{Ed25519KeyType, RepoId, RoleType}
+import com.advancedtelematic.tuf.reposerver.db.SignedRoleRepositorySupport
+import com.advancedtelematic.tuf.reposerver.util.{FakeKeyserverClient, TufReposerverSpec}
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.time.{Seconds, Span}
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext.Implicits
+
+
+class SignedRoleGenerationSpec extends TufReposerverSpec with DatabaseSpec with SignedRoleRepositorySupport with ScalaFutures {
+  override implicit val ec: ExecutionContext = Implicits.global
+
+  override implicit def patienceConfig = PatienceConfig().copy(timeout = Span(5, Seconds))
+
+  val fakeKeyserverClient: FakeKeyserverClient = new FakeKeyserverClient
+
+  val signedRoleGeneration = new SignedRoleGeneration(fakeKeyserverClient)
+
+  def setupRepo(): Future[RepoId] = for {
+    repoId <- FastFuture.successful(RepoId.generate())
+    _ <- fakeKeyserverClient.createRoot(repoId, Ed25519KeyType)
+    _ <- signedRoleGeneration.regenerateAllSignedRoles(repoId)
+  } yield repoId
+
+  test("renewal of snapshots renews also timestamps") {
+    val repoId = setupRepo().futureValue
+
+    val oldTimestamps = signedRoleGeneration.findRole[TimestampRole](repoId).futureValue
+    val oldSnapshots = signedRoleGeneration.findRole[SnapshotRole](repoId).futureValue
+
+    signedRoleRepository.persist[SnapshotRole](oldSnapshots.copy(expiresAt = Instant.now().minusSeconds(60)), forceVersion = true).futureValue
+
+    val renewedSnapshots = signedRoleGeneration.findRole(repoId, RoleType.SNAPSHOT).futureValue
+    val renewedTimestampsDb = signedRoleRepository.find[TimestampRole](repoId).futureValue
+    val (_, renewedSnapshotsHash) = renewedTimestampsDb.role.meta(RoleType.SNAPSHOT.metaPath).hashes.head
+
+    renewedSnapshots.checksum shouldNot be(oldSnapshots.checksum)
+    renewedSnapshots.version shouldBe oldSnapshots.version + 1
+
+    renewedTimestampsDb.version shouldBe oldTimestamps.version + 1
+    renewedSnapshotsHash shouldBe renewedSnapshots.checksum.hash
+  }
+
+  test("renewal of targets renews also snapshots and timestamps") {
+    val repoId = setupRepo().futureValue
+
+    val oldTargets = signedRoleGeneration.findRole(repoId, RoleType.TARGETS).futureValue
+    val oldSnapshots = signedRoleGeneration.findRole(repoId, RoleType.SNAPSHOT).futureValue
+    val oldTimestamps = signedRoleGeneration.findRole(repoId, RoleType.TIMESTAMP).futureValue
+
+    signedRoleRepository.persist[TargetsRole](oldTargets.copy(expiresAt = Instant.now().minusSeconds(60)), forceVersion = true).futureValue
+
+    val renewedTargets = signedRoleGeneration.findRole(repoId, RoleType.TARGETS).futureValue
+    val renewedSnapshots = signedRoleRepository.find[SnapshotRole](repoId).futureValue
+    val renewedTimestamps = signedRoleGeneration.findRole[TimestampRole](repoId).futureValue
+    val (_, renewedSnapshotsHash) = renewedTimestamps.role.meta(RoleType.SNAPSHOT.metaPath).hashes.head
+
+    val renewedSnaphotsParsed = renewedSnapshots.role
+    val (_, renewedTargetsHash) = renewedSnaphotsParsed.meta(RoleType.TARGETS.metaPath).hashes.head
+
+    renewedTargetsHash shouldBe renewedTargets.checksum.hash
+    renewedSnapshots.version shouldBe oldSnapshots.version + 1
+
+    renewedTimestamps.version shouldBe oldTimestamps.version + 1
+    renewedSnapshotsHash shouldBe renewedSnapshots.checksum.hash
+  }
+}


### PR DESCRIPTION
When snapshots.json was refreshed due to an expiration,
timestamps.json was not refreshed to reflect that change. The same was
happening with targets.json and it's dependencies (snapshots.json -> targets.json)

This required a sizeable refactor otherwise we could not have the
refresh operation with type safe signatures as didn't have a way
during compilation to distinguish from a targets.json in SignedRole or
a snapshots.json in a SignedRole, for example.

This is still not perfect, there is still some complexity and we now have one extra type, but it does give us some type safety which I hope will help us avoid some of these bugs in the future.