### PR TITLE
Make garage-sign read "api_gateway.url" in credentials.zip

### DIFF
--- a/cli/src/main/scala/com/advancedtelematic/tuf/cli/repo/RepoManagement.scala
+++ b/cli/src/main/scala/com/advancedtelematic/tuf/cli/repo/RepoManagement.scala
@@ -171,7 +171,7 @@ protected object ZipRepoInitialization {
     def readRepoUri(src: ZipFile): Try[URI] = {
       val filename = repoServerType match {
         case RepoServer => "tufrepo.url"
-        case Director => "api-gateway.url"
+        case Director => "api_gateway.url"
       }
 
       for {


### PR DESCRIPTION
... and not "api-gateway.url", since that is what app will put in there (see https://github.com/advancedtelematic/ota-plus-server/blob/831cc34f8c2f10c1ce581c99fa64fdb20376a23d/ota-plus-web/app/com/advancedtelematic/controllers/ClientToolController.scala#L143), since credentials.zip already contains "autoprov_credentials.p12".