### PR TITLE
Publish latest tag when building image

### DIFF
--- a/project/Packaging.scala
+++ b/project/Packaging.scala
@@ -15,7 +15,7 @@ object Packaging {
 
       packageName in Docker := distPackageName,
 
-      dockerUpdateLatest := false,
+      dockerUpdateLatest := true,
 
       dockerAliases ++= Seq(dockerAlias.value.withTag(git.gitHeadCommit.value)),
 


### PR DESCRIPTION
Some systems need to know what is the latest container version. For
example HAT deployments.

CI using gitlab no longer pushes `artifacts.txt` to S3 as teamcity
did. So we need to push this tag to `:latest` so that services can use
the `latest` tag.