### PR TITLE
Feat/ota 4632/upload large files with long timeout

### DIFF
--- a/deploy/gitlab-db-setup.sh
+++ b/deploy/gitlab-db-setup.sh
@@ -8,7 +8,7 @@ HOST=$2
 if [ "$MYSQL_COMMAND" = "mysql" ]; then
     MYSQL=mysql
 else
-    MYSQL="docker run -i --rm --link $HOST mariadb:10.1 mysql"
+    MYSQL="docker run -i --rm --link $HOST mariadb:10.2 mysql"
 fi
 
 $MYSQL -v -h $HOST -u root -proot <<EOF

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.8

--- a/reposerver/src/main/resources/application.conf
+++ b/reposerver/src/main/resources/application.conf
@@ -26,6 +26,16 @@ akka {
       max-connections = ${?AKKA_HTTP_MAX_CONNECTIONS}
       backlog = 2000
       backlog = ${?AKKA_HTTP_BACKLOG}
+
+      // Akka HTTP default value
+      idle-timeout = 60 s
+      idle-timeout = ${?AKKA_HTTP_SERVER_IDLE_TIMEOUT}
+    }
+
+    client {
+      // Akka HTTP default value
+      idle-timeout = 60 s
+      idle-timeout = ${?AKKA_HTTP_CLIENT_IDLE_TIMEOUT}
     }
   }
 }
@@ -108,8 +118,11 @@ keyserver {
 }
 
 reposerver {
-  sizeLimit = 536870912 // 512Mb
+  # add some extra bytes for headers
+  sizeLimit = 536872000 // > 512Mb
   sizeLimit = ${?TUF_REPOSERVER_SIZE_LIMIT}
+  uploadRequestTimeout = akka-http.server.request-timeout
+  uploadRequestTimeout = ${?TUF_REPOSERVER_UPLOAD_REQUEST_TIMEOUT}
 }
 
 

--- a/reposerver/src/main/scala/com/advancedtelematic/tuf/reposerver/Boot.scala
+++ b/reposerver/src/main/scala/com/advancedtelematic/tuf/reposerver/Boot.scala
@@ -16,13 +16,16 @@ import com.advancedtelematic.libats.messaging.MessageBus
 import com.advancedtelematic.libats.slick.db.{BootMigrations, DatabaseConfig}
 import com.advancedtelematic.libats.slick.monitoring.DatabaseMetrics
 import com.advancedtelematic.libtuf_server.keyserver.KeyserverHttpClient
-import com.advancedtelematic.metrics.{AkkaHttpRequestMetrics, MetricsSupport}
 import com.advancedtelematic.metrics.prometheus.PrometheusMetricsSupport
+import com.advancedtelematic.metrics.{AkkaHttpRequestMetrics, MetricsSupport}
 import com.advancedtelematic.tuf.reposerver.http.{NamespaceValidation, TufReposerverRoutes}
 import com.advancedtelematic.tuf.reposerver.target_store._
 import com.amazonaws.regions.Regions
 import com.typesafe.config.ConfigFactory
 import org.bouncycastle.jce.provider.BouncyCastleProvider
+
+import scala.concurrent.duration.Duration
+
 
 trait Settings {
   private lazy val _config = ConfigFactory.load()
@@ -45,6 +48,9 @@ trait Settings {
   lazy val useS3 = _config.getString("storage.type").equals("s3")
 
   lazy val userRepoSizeLimit = _config.getLong("reposerver.sizeLimit")
+
+  // not using Config.getDuration() here because that parses different formats than what Akka uses
+  lazy val userRepoUploadRequestTimeout = Duration(_config.getString("reposerver.uploadRequestTimeout"))
 }
 
 object Boot extends BootApp

--- a/reposerver/src/main/scala/com/advancedtelematic/tuf/reposerver/Boot.scala
+++ b/reposerver/src/main/scala/com/advancedtelematic/tuf/reposerver/Boot.scala
@@ -44,7 +44,7 @@ trait Settings {
 
   lazy val useS3 = _config.getString("storage.type").equals("s3")
 
-  lazy val userRepoSizeLimit = _config.getInt("reposerver.sizeLimit")
+  lazy val userRepoSizeLimit = _config.getLong("reposerver.sizeLimit")
 }
 
 object Boot extends BootApp

--- a/reposerver/src/main/scala/com/advancedtelematic/tuf/reposerver/http/RepoResource.scala
+++ b/reposerver/src/main/scala/com/advancedtelematic/tuf/reposerver/http/RepoResource.scala
@@ -121,12 +121,14 @@ class RepoResource(keyserverClient: KeyserverClient, namespaceValidation: Namesp
   private def addTargetFromContent(namespace: Namespace, filename: TargetFilename, repoId: RepoId): Route = {
     targetCustomParameters { custom =>
       withSizeLimit(userRepoSizeLimit) {
-        fileUpload("file") { case (_, file) =>
-          complete {
-            for {
-              item <- targetStore.store(repoId, filename, file, custom)
-              result <- addTargetItem(namespace, item)
-            } yield result
+        withRequestTimeout(userRepoUploadRequestTimeout) {
+          fileUpload("file") { case (_, file) =>
+            complete {
+              for {
+                item <- targetStore.store(repoId, filename, file, custom)
+                result <- addTargetItem(namespace, item)
+              } yield result
+            }
           }
         }
       } ~

--- a/reposerver/src/test/resources/application.conf
+++ b/reposerver/src/test/resources/application.conf
@@ -5,3 +5,7 @@ database = {
 storage {
   type = "local"
 }
+
+reposerver {
+  sizeLimit = 4000000000
+}


### PR DESCRIPTION
Tested by uploading a 3G file to the reposerver directly with the settings:

  TUF_REPOSERVER_SIZE_LIMIT: 3221227000
  TUF_REPOSERVER_UPLOAD_REQUEST_TIMEOUT: 3min
  AKKA_HTTP_SERVER_IDLE_TIMEOUT: 5min
  AKKA_HTTP_CLIENT_IDLE_TIMEOUT: 4min
