### PR TITLE
Stream file upload to s3 if client supports it

### DIFF
--- a/reposerver/src/main/scala/com/advancedtelematic/tuf/reposerver/target_store/LocalTargetStoreEngine.scala
+++ b/reposerver/src/main/scala/com/advancedtelematic/tuf/reposerver/target_store/LocalTargetStoreEngine.scala
@@ -94,4 +94,8 @@ class LocalTargetStoreEngine(root: File)(implicit val system: ActorSystem, val m
       }
     }
   }
+
+  override def storeStream(repoId: RepoId, filename: TargetFilename, fileData: Source[ByteString, Any], size: Long): Future[TargetStoreResult] = {
+    store(repoId, filename, fileData)
+  }
 }

--- a/reposerver/src/main/scala/com/advancedtelematic/tuf/reposerver/target_store/TargetStore.scala
+++ b/reposerver/src/main/scala/com/advancedtelematic/tuf/reposerver/target_store/TargetStore.scala
@@ -24,6 +24,7 @@ import com.advancedtelematic.libtuf_server.repo.server.DataType._
 import com.advancedtelematic.tuf.reposerver.data.RepositoryDataType._
 import com.advancedtelematic.tuf.reposerver.data.RepositoryDataType.TargetItem
 import com.advancedtelematic.tuf.reposerver.http.Errors
+import com.sun.corba.se.spi.ior.ObjectId
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NoStackTrace
@@ -63,6 +64,13 @@ class TargetStore(roleKeyStore: KeyserverClient,
   def store(repoId: RepoId, targetFile: TargetFilename, fileData: Source[ByteString, Any], custom: TargetCustom): Future[TargetItem] = {
     for {
       storeResult <- engine.store(repoId, targetFile, fileData)
+      _ <- publishUploadMessages(repoId)
+    } yield TargetItem(repoId, targetFile, storeResult.uri.some, storeResult.checksum, storeResult.size, Some(custom))
+  }
+
+  def storeStream(repoId: RepoId, targetFile: TargetFilename, fileData: Source[ByteString, Any], custom: TargetCustom, size: Long): Future[TargetItem] = {
+    for {
+      storeResult <- engine.storeStream(repoId, targetFile, fileData, size)
       _ <- publishUploadMessages(repoId)
     } yield TargetItem(repoId, targetFile, storeResult.uri.some, storeResult.checksum, storeResult.size, Some(custom))
   }

--- a/reposerver/src/main/scala/com/advancedtelematic/tuf/reposerver/target_store/TargetStoreEngine.scala
+++ b/reposerver/src/main/scala/com/advancedtelematic/tuf/reposerver/target_store/TargetStoreEngine.scala
@@ -30,6 +30,8 @@ object TargetStoreEngine {
 trait TargetStoreEngine {
   private val _log = LoggerFactory.getLogger(this.getClass)
 
+  def storeStream(repoId: RepoId, filename: TargetFilename, fileData: Source[ByteString, Any], size: Long): Future[TargetStoreResult]
+
   def store(repoId: RepoId, filename: TargetFilename, fileData: Source[ByteString, Any]): Future[TargetStoreResult]
 
   def retrieve(repoId: RepoId, filename: TargetFilename): Future[TargetRetrieveResult]


### PR DESCRIPTION
If client uploads the file contents as request entity, and a valid
`Content-Length` header, upload file to s3 instead of buffering
locally.

This is equivalent to the following curl command:

```
curl -H 'application/octet-stream' --data-binary @myfile.bin host:/api/v2/objects/:object-i
```

Not this is different from the request the UI currently uses, which
includes a form field and does not provide a valid size for the file.